### PR TITLE
feat: 3D 은하 프론트엔드 초기 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,0 @@
-# 백엔드 REST API 주소
-VITE_API_BASE_URL=http://localhost:8080
-
-# 백엔드 WebSocket 주소
-VITE_WS_URL=ws://localhost:8080/ws

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GitHub Universe — 오픈소스 생태계 3D 시각화</title>
   </head>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <!-- 우주 배경 -->
+  <circle cx="32" cy="32" r="32" fill="#020408"/>
+
+  <!-- 외부 glow 링 -->
+  <circle cx="32" cy="32" r="20" fill="none" stroke="#4f8ef7" stroke-width="0.6" opacity="0.25"/>
+
+  <!-- 별 모양 (5각) -->
+  <polygon
+    points="32,10 35.9,22.5 49,22.5 38.5,30 42.4,42.5 32,35 21.6,42.5 25.5,30 15,22.5 28.1,22.5"
+    fill="#4f8ef7"
+    opacity="0.95"
+  />
+
+  <!-- 중심 코어 glow -->
+  <circle cx="32" cy="32" r="5" fill="white" opacity="0.7"/>
+  <circle cx="32" cy="32" r="8" fill="#4f8ef7" opacity="0.3"/>
+
+  <!-- 소형 주변 별 -->
+  <circle cx="14" cy="14" r="1.2" fill="white" opacity="0.6"/>
+  <circle cx="52" cy="18" r="0.8" fill="#f7d44f" opacity="0.7"/>
+  <circle cx="10" cy="48" r="0.9" fill="#4da8e0" opacity="0.6"/>
+  <circle cx="54" cy="50" r="1.1" fill="white" opacity="0.5"/>
+  <circle cx="44" cy="8"  r="0.7" fill="#f07050" opacity="0.6"/>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,23 +5,47 @@ import { useGalaxyStore } from '@/store/useGalaxyStore'
 import { useMockWebSocket } from '@/api/mockWebSocket'
 import { connectWebSocket, disconnectWebSocket } from '@/api/websocket'
 import { DUMMY_REPOSITORIES, DUMMY_SCORES } from '@/data/dummy'
+// ── 2D UI 컴포넌트 ──────────────────────────────────────────────────
+import SidePanel from '@/components/panel/SidePanel'
+import Tooltip from '@/components/overlay/Tooltip'
+import Legend from '@/components/overlay/Legend'
+import HelpOverlay from '@/components/overlay/HelpOverlay'
+import LoginButton from '@/components/overlay/LoginButton'
+import { useUIStore } from '@/store/useUIStore'
 
 /**
  * App.tsx — 최상위 레이아웃
  *
- * [현재 1~4주차]
+ * [1~4주차]
  *  - 더미 데이터 로드 후 3D 씬 렌더링
  *  - DEV: useMockWebSocket()으로 실시간 점수 변화 시뮬레이션
  *  - PROD: connectWebSocket()으로 실제 BE WebSocket 연결
  *
- * [TODO 3~4주차 BE 완성 후]
+ * [3~6주차]
+ *  - Tooltip: 별 hover 시 미리보기
+ *  - SidePanel: 별 클릭 시 상세 정보 + 점수 차트
+ *  - Legend: 언어 색상 범례
+ *  - HelpOverlay: 카메라 조작 가이드
+ *
+ * [7~8주차]
+ *  - SidePanel 내 RAG 분석 ("왜?" 버튼)
+ *  - 블랙홀 스파이럴 이펙트 (Star.tsx에서 자동 활성화)
+ *
+ * [9~10주차]
+ *  - LoginButton: GitHub OAuth
+ *  - My Galaxy 필터 (SidePanel 즐겨찾기 토글)
+ *
+ * [TODO BE 준비 후]
  *  - setRepositories → GET /api/repos API 호출로 교체
  *  - DUMMY_SCORES 제거 → 초기 점수는 API에서 수신
  */
 export default function App() {
-  const { setRepositories, updateScore } = useGalaxyStore()
+  const { setRepositories, updateScore, isConnected } = useGalaxyStore()
+  const isPanelOpen = useUIStore((s) => s.isPanelOpen)
 
   // ── 초기 데이터 로드 ───────────────────────────────────────────
+  // DEV: 더미 데이터로 초기화 (BE API 준비 전)
+  // PROD: 실제 API 호출로 교체 예정
   useEffect(() => {
     setRepositories(DUMMY_REPOSITORIES)
     DUMMY_SCORES.forEach((score) => updateScore(score.repoId, score))
@@ -29,31 +53,56 @@ export default function App() {
 
   // ── WebSocket 연결 ─────────────────────────────────────────────
   // DEV: 목 WebSocket (BE 없이 실시간 시뮬레이션)
-  // PROD: 실제 WebSocket (아래 useEffect)
+  // PROD: 실제 BE WebSocket 연결
   useMockWebSocket()
 
   useEffect(() => {
     if (import.meta.env.DEV) return  // 개발 중엔 Mock 사용
-
     connectWebSocket()
     return () => disconnectWebSocket()
   }, [])
 
   return (
-    <div className="relative w-full h-full">
-      {/* ── 3D 캔버스 (전체 화면) ── */}
-      <Scene />
-
-      {/* ── 2D UI 오버레이 (유민님이 해주시면 됩니다. 구현 예정 구역) ── */}
-      {/* <SidePanel /> */}
-      {/* <Tooltip /> */}
-
-      {/* 임시 상태 표시 (개발 중 확인용) */}
-      <div className="absolute top-4 left-4 text-xs text-white/40 font-mono pointer-events-none">
-        GitHub Universe — 개발 중
+    <div className="relative w-full h-full overflow-hidden">
+      {/* ── 3D 캔버스 (전체 화면) ──────────────────────────────────── */}
+      {/*
+        사이드 패널이 열리면 캔버스를 살짝 왼쪽으로 밀어서 공간감을 준다.
+        transition으로 부드럽게 이동.
+      */}
+      <div
+        className="absolute inset-0 transition-transform duration-300 ease-out"
+        style={{ transform: isPanelOpen ? 'translateX(-80px)' : 'translateX(0)' }}
+      >
+        <Scene />
       </div>
 
-      {/* FPS 모니터 (DEV only) */}
+      {/* ── 2D 오버레이 영역 ────────────────────────────────────────── */}
+
+      {/* 접속 상태 + 타이틀 (좌상단) */}
+      <div className="absolute top-4 left-4 text-xs text-white/40 font-mono pointer-events-none z-10 flex items-center gap-2">
+        <span
+          className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${isConnected ? 'bg-green-400' : 'bg-white/20'}`}
+          title={isConnected ? '실시간 연결됨' : '연결 대기'}
+        />
+        <span>GitHub Universe</span>
+      </div>
+
+      {/* 호버 툴팁 */}
+      <Tooltip />
+
+      {/* 사이드 패널 (우측) */}
+      <SidePanel />
+
+      {/* 언어 범례 (좌하단) */}
+      <Legend />
+
+      {/* 도움말 (우하단) */}
+      <HelpOverlay />
+
+      {/* GitHub 로그인 버튼 (우상단) — 9~10주차 */}
+      <LoginButton />
+
+      {/* FPS 모니터 (DEV only, 우하단 위) */}
       <FrameMonitor />
     </div>
   )

--- a/src/canvas/Scene.tsx
+++ b/src/canvas/Scene.tsx
@@ -26,6 +26,7 @@ import Cluster from './objects/Cluster'
 import MeteorEffect from './effects/MeteorEffect'
 import SpaceControls from './controls/SpaceControls'
 import { useGalaxyStore } from '@/store/useGalaxyStore'
+import { useUIStore } from '@/store/useUIStore'
 import { usePhysics } from '@/hooks/3d/usePhysics'
 
 // ── Physics + Stars + Clusters — Canvas 내부 컴포넌트 ─────────────
@@ -93,11 +94,12 @@ function GalaxyScene() {
 export default function Scene() {
   return (
     <Canvas
-      camera={{ position: [0, 0, 200], fov: 60, near: 0.1, far: 2500 }}
+      camera={{ position: [0, 0, 220], fov: 60, near: 0.1, far: 2500 }}
       gl={{ antialias: true, alpha: false }}
       style={{ background: '#020408' }}
-      // frameloop: always → 물리 애니메이션을 위해 항상 렌더
       frameloop="always"
+      // 빈 공간 클릭 → 패널 닫기 + 카메라 추적 해제
+      onPointerMissed={() => useUIStore.getState().closePanel()}
     >
       <GalaxyScene />
     </Canvas>

--- a/src/canvas/controls/SpaceControls.tsx
+++ b/src/canvas/controls/SpaceControls.tsx
@@ -1,164 +1,246 @@
 /**
- * SpaceControls.tsx
+ * SpaceControls.tsx — 360° 구형 좌표계 오비탈 카메라 (v2)
  *
- * 넓은 우주 공간을 탐험하는 카메라 컨트롤.
- * OrbitControls(한 점 고정 회전)와 달리 카메라 자체가 공간을 이동한다.
+ * 좌표계:
+ *   camera.position = target + sphere(theta, phi, radius)
+ *   theta  = 방위각 (Y축 중심, 제한 없음 → 360° 수평 회전)
+ *   phi    = 앙각   (0 = 위쪽, π = 아래쪽, 극점 제외 전체 범위)
+ *   radius = 카메라 ↔ target 거리 (줌)
+ *   target = 카메라가 바라보는 3D 공간의 한 점 (팬으로 자유 이동)
  *
  * 인터랙션:
- *  - 좌클릭 드래그 → X/Y 방향 패닝 (우주 이동)
- *  - 스크롤 휠    → Z 방향 줌인/아웃
- *  - 드래그 해제 후 → 관성(inertia) 적용, 서서히 감속
- *  - 터치 드래그  → 패닝
- *  - 터치 핀치    → 줌인/아웃
+ *   좌드래그 → 360° 오비트
+ *   우드래그 → target 팬 (고정 중심 없는 자유 탐험)
+ *   스크롤   → 줌인/아웃 (lerp로 부드럽게)
+ *   관성     → 드래그 해제 후 서서히 감속
+ *   별 클릭  → 해당 별 추적 + 줌인 (followedRepoId)
+ *   X 클릭 / 빈 화면 클릭 → 추적 해제 + 전체 뷰로 부드럽게 줌아웃
  */
 
 import { useEffect, useRef } from 'react'
 import { useThree, useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
+import { physicsStore } from '@/store/physicsStore'
+import { useUIStore } from '@/store/useUIStore'
 
-// ── 카메라 이동 한계 ──────────────────────────
-const BOUNDS_XY = 600    // X/Y 이동 최대 범위
-const MIN_Z = 25         // 줌인 최소 거리
-const MAX_Z = 700        // 줌아웃 최대 거리
-const INERTIA_DECAY = 0.88 // 관성 감쇠 계수 (0~1, 높을수록 더 오래 미끄러짐)
-const INERTIA_STOP = 0.05  // 이 값 이하면 속도 0으로 고정
+// ── 상수 ──────────────────────────────────────────────────────────
+const MIN_RADIUS          = 15
+const MAX_RADIUS          = 900
+const DEFAULT_RADIUS      = 220    // 추적 해제 시 복귀할 기본 거리
+const FOLLOW_RADIUS       = 45     // 별 추적 시 목표 거리
+const ORBIT_SENS          = 0.004
+const PAN_SENS            = 0.0012
+const ZOOM_SENS           = 0.0012
+const INERTIA_DECAY       = 0.90
+const INERTIA_STOP        = 0.00015
+const FOLLOW_LERP         = 5      // 별 추적 target 이동 속도
+const ZOOM_LERP           = 7      // 줌 lerp 속도
 
+// ─────────────────────────────────────────────────────────────────
 export default function SpaceControls() {
   const { camera, gl } = useThree()
 
-  // 드래그 상태
-  const isDragging = useRef(false)
-  const lastMouse = useRef({ x: 0, y: 0 })
+  // ── Zustand: 별 추적 상태 (ref로 동기화 → useEffect 재등록 방지) ─
+  const followedRepoId      = useUIStore((s) => s.followedRepoId)
+  const setCameraFollow     = useUIStore((s) => s.setCameraFollow)
+  const followedRepoIdRef   = useRef<number | null>(null)
+  const setCameraFollowRef  = useRef(setCameraFollow)
+  followedRepoIdRef.current  = followedRepoId
+  setCameraFollowRef.current = setCameraFollow
 
-  // 관성 속도 (frame마다 카메라에 적용 후 감쇠)
-  const velocity = useRef({ x: 0, y: 0 })
+  // ── 구형 좌표 refs ────────────────────────────────────────────
+  const thetaRef        = useRef(0)
+  const phiRef          = useRef(Math.PI / 2)
+  const radiusRef       = useRef(DEFAULT_RADIUS)
+  const targetRadiusRef = useRef(DEFAULT_RADIUS)
+  const targetRef       = useRef(new THREE.Vector3(0, 0, 0))
 
-  // 터치 핀치 줌 — 이전 두 손가락 거리
-  const lastPinchDist = useRef<number | null>(null)
+  // ── 드래그 / 관성 ────────────────────────────────────────────
+  const dragModeRef   = useRef<'orbit' | 'pan' | null>(null)
+  const lastMouseRef  = useRef({ x: 0, y: 0 })
+  const orbitVelRef   = useRef({ theta: 0, phi: 0 })
 
-  // ── 패닝 계수 계산 ─────────────────────────
-  // 멀리 있을수록(Z 클수록) 같은 픽셀 이동에 더 많이 이동해야 자연스럽다
-  const getPanFactor = () => {
-    return camera.position.z / (window.innerHeight * 1.2)
+  // ── 이전 follow 값 (release 감지용) ─────────────────────────
+  const prevFollowedRef = useRef<number | null>(null)
+
+  // ── 헬퍼: 카메라 위치·방향 적용 ─────────────────────────────
+  const applyCamera = () => {
+    const r = radiusRef.current
+    const t = thetaRef.current
+    const p = phiRef.current
+    const tgt = targetRef.current
+    camera.position.set(
+      tgt.x + r * Math.sin(p) * Math.sin(t),
+      tgt.y + r * Math.cos(p),
+      tgt.z + r * Math.sin(p) * Math.cos(t),
+    )
+    camera.lookAt(tgt)
   }
 
-  // ── 매 프레임: 관성 적용 + 경계 클램핑 ─────
-  useFrame(() => {
-    if (!isDragging.current) {
-      camera.position.x += velocity.current.x
-      camera.position.y += velocity.current.y
+  // ── 헬퍼: 팬용 right/up 벡터 ─────────────────────────────────
+  const getRightUp = () => {
+    const t = thetaRef.current
+    const p = phiRef.current
+    const right = new THREE.Vector3(Math.cos(t), 0, -Math.sin(t))
+    const up    = new THREE.Vector3(
+      -Math.sin(t) * Math.cos(p),
+       Math.sin(p),
+      -Math.cos(t) * Math.cos(p),
+    )
+    return { right, up }
+  }
 
-      velocity.current.x *= INERTIA_DECAY
-      velocity.current.y *= INERTIA_DECAY
+  // ── 매 프레임 루프 ────────────────────────────────────────────
+  useFrame((_, delta) => {
+    const dt = Math.min(delta, 0.05)
 
-      // 아주 작은 값은 0으로 끊기
-      if (Math.abs(velocity.current.x) < INERTIA_STOP) velocity.current.x = 0
-      if (Math.abs(velocity.current.y) < INERTIA_STOP) velocity.current.y = 0
+    // 1. 추적 해제 감지 → 전체 뷰로 줌아웃
+    const currFollow = followedRepoIdRef.current
+    if (prevFollowedRef.current !== null && currFollow === null) {
+      targetRadiusRef.current = DEFAULT_RADIUS
+      // target을 서서히 원점 방향으로 되돌리지는 않음 (갑작스러운 점프 방지)
+      // radius만 넓히면 자연스럽게 전체 뷰가 보임
+    }
+    prevFollowedRef.current = currFollow
+
+    // 2. 줌 lerp
+    radiusRef.current += (targetRadiusRef.current - radiusRef.current) * Math.min(ZOOM_LERP * dt, 1)
+    radiusRef.current = Math.max(MIN_RADIUS, Math.min(MAX_RADIUS, radiusRef.current))
+
+    // 3. 별 추적
+    if (currFollow !== null) {
+      const entry = physicsStore.entries.get(currFollow)
+      if (entry) {
+        targetRef.current.lerp(entry.position, Math.min(FOLLOW_LERP * dt, 1))
+        targetRadiusRef.current += (FOLLOW_RADIUS - targetRadiusRef.current) * Math.min(4 * dt, 1)
+      }
     }
 
-    // 경계 클램핑
-    camera.position.x = Math.max(-BOUNDS_XY, Math.min(BOUNDS_XY, camera.position.x))
-    camera.position.y = Math.max(-BOUNDS_XY, Math.min(BOUNDS_XY, camera.position.y))
-    camera.position.z = Math.max(MIN_Z, Math.min(MAX_Z, camera.position.z))
+    // 4. 오비트 관성
+    if (dragModeRef.current === null) {
+      thetaRef.current += orbitVelRef.current.theta
+      phiRef.current   += orbitVelRef.current.phi
+      orbitVelRef.current.theta *= INERTIA_DECAY
+      orbitVelRef.current.phi   *= INERTIA_DECAY
+      if (Math.abs(orbitVelRef.current.theta) < INERTIA_STOP) orbitVelRef.current.theta = 0
+      if (Math.abs(orbitVelRef.current.phi)   < INERTIA_STOP) orbitVelRef.current.phi   = 0
+    }
+
+    // 5. phi 클램핑 (극점 gimbal lock 방지)
+    phiRef.current = Math.max(0.05, Math.min(Math.PI - 0.05, phiRef.current))
+
+    // 6. 카메라 적용
+    applyCamera()
   })
 
-  // ── 이벤트 리스너 등록/해제 ─────────────────
+  // ── 이벤트 등록 (마운트 시 1회) ──────────────────────────────
   useEffect(() => {
     const canvas = gl.domElement
     canvas.style.cursor = 'grab'
 
-    // ── 마우스 ──────────────────────────────
     const onMouseDown = (e: MouseEvent) => {
-      if (e.button !== 0) return // 좌클릭만
-      isDragging.current = true
-      velocity.current = { x: 0, y: 0 } // 드래그 시작 시 관성 초기화
-      lastMouse.current = { x: e.clientX, y: e.clientY }
+      if (e.button === 0) {
+        dragModeRef.current = 'orbit'
+        // 오비트 드래그 시작 → 별 추적 해제
+        if (followedRepoIdRef.current !== null) {
+          setCameraFollowRef.current(null)
+        }
+      } else if (e.button === 2) {
+        dragModeRef.current = 'pan'
+      } else {
+        return
+      }
+      orbitVelRef.current = { theta: 0, phi: 0 }
+      lastMouseRef.current = { x: e.clientX, y: e.clientY }
       canvas.style.cursor = 'grabbing'
     }
 
     const onMouseMove = (e: MouseEvent) => {
-      if (!isDragging.current) return
+      if (!dragModeRef.current) return
+      const dx = e.clientX - lastMouseRef.current.x
+      const dy = e.clientY - lastMouseRef.current.y
 
-      const dx = e.clientX - lastMouse.current.x
-      const dy = e.clientY - lastMouse.current.y
-      const factor = getPanFactor()
-
-      const vx = -dx * factor
-      const vy = dy * factor
-
-      camera.position.x += vx
-      camera.position.y += vy
-      // 관성을 위해 현재 속도 기록
-      velocity.current = { x: vx, y: vy }
-
-      lastMouse.current = { x: e.clientX, y: e.clientY }
+      if (dragModeRef.current === 'orbit') {
+        const dTheta = -dx * ORBIT_SENS
+        const dPhi   = -dy * ORBIT_SENS
+        thetaRef.current += dTheta
+        phiRef.current   += dPhi
+        orbitVelRef.current = { theta: dTheta, phi: dPhi }
+      } else if (dragModeRef.current === 'pan') {
+        const { right, up } = getRightUp()
+        const scale = radiusRef.current * PAN_SENS
+        targetRef.current.addScaledVector(right,  dx * scale)
+        targetRef.current.addScaledVector(up,    -dy * scale)
+      }
+      lastMouseRef.current = { x: e.clientX, y: e.clientY }
     }
 
     const onMouseUp = () => {
-      isDragging.current = false
+      dragModeRef.current = null
       canvas.style.cursor = 'grab'
     }
 
-    // ── 휠 줌 ───────────────────────────────
     const onWheel = (e: WheelEvent) => {
       e.preventDefault()
-      // trackpad pinch는 deltaY가 작고 deltaMode=0, 마우스 휠은 크다
-      const factor = e.ctrlKey ? 0.003 : 0.0012
-      const zoomMultiplier = 1 + e.deltaY * factor
-      camera.position.z = Math.max(
-        MIN_Z,
-        Math.min(MAX_Z, camera.position.z * zoomMultiplier),
+      const factor = e.ctrlKey ? 0.005 : ZOOM_SENS
+      targetRadiusRef.current = Math.max(
+        MIN_RADIUS,
+        Math.min(MAX_RADIUS, targetRadiusRef.current * (1 + e.deltaY * factor)),
       )
     }
 
-    // ── 터치 (모바일) ─────────────────────────
+    const onContextMenu = (e: Event) => e.preventDefault()
+
+    // ── 터치 ─────────────────────────────────────────────────
+    let lastPinchDist: number | null = null
+
     const onTouchStart = (e: TouchEvent) => {
       if (e.touches.length === 1) {
-        isDragging.current = true
-        velocity.current = { x: 0, y: 0 }
-        lastMouse.current = { x: e.touches[0].clientX, y: e.touches[0].clientY }
+        dragModeRef.current = 'orbit'
+        orbitVelRef.current = { theta: 0, phi: 0 }
+        lastMouseRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY }
+        if (followedRepoIdRef.current !== null) setCameraFollowRef.current(null)
       } else if (e.touches.length === 2) {
-        // 핀치 시작 — 두 손가락 거리 저장
+        dragModeRef.current = null
         const dx = e.touches[0].clientX - e.touches[1].clientX
         const dy = e.touches[0].clientY - e.touches[1].clientY
-        lastPinchDist.current = Math.hypot(dx, dy)
-        isDragging.current = false
+        lastPinchDist = Math.hypot(dx, dy)
       }
     }
 
     const onTouchMove = (e: TouchEvent) => {
       e.preventDefault()
-      if (e.touches.length === 1 && isDragging.current) {
-        const dx = e.touches[0].clientX - lastMouse.current.x
-        const dy = e.touches[0].clientY - lastMouse.current.y
-        const factor = getPanFactor()
-
-        const vx = -dx * factor
-        const vy = dy * factor
-        camera.position.x += vx
-        camera.position.y += vy
-        velocity.current = { x: vx, y: vy }
-        lastMouse.current = { x: e.touches[0].clientX, y: e.touches[0].clientY }
-      } else if (e.touches.length === 2 && lastPinchDist.current !== null) {
-        // 핀치 줌
+      if (e.touches.length === 1 && dragModeRef.current === 'orbit') {
+        const dx = e.touches[0].clientX - lastMouseRef.current.x
+        const dy = e.touches[0].clientY - lastMouseRef.current.y
+        const dTheta = -dx * ORBIT_SENS
+        const dPhi   = -dy * ORBIT_SENS
+        thetaRef.current += dTheta
+        phiRef.current   += dPhi
+        orbitVelRef.current = { theta: dTheta, phi: dPhi }
+        lastMouseRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY }
+      } else if (e.touches.length === 2 && lastPinchDist !== null) {
         const dx = e.touches[0].clientX - e.touches[1].clientX
         const dy = e.touches[0].clientY - e.touches[1].clientY
         const dist = Math.hypot(dx, dy)
-        const ratio = lastPinchDist.current / dist // 줄어들면 >1 (줌아웃)
-        camera.position.z = Math.max(MIN_Z, Math.min(MAX_Z, camera.position.z * ratio))
-        lastPinchDist.current = dist
+        targetRadiusRef.current = Math.max(
+          MIN_RADIUS,
+          Math.min(MAX_RADIUS, targetRadiusRef.current * (lastPinchDist / dist)),
+        )
+        lastPinchDist = dist
       }
     }
 
     const onTouchEnd = () => {
-      isDragging.current = false
-      lastPinchDist.current = null
+      dragModeRef.current = null
+      lastPinchDist = null
     }
 
-    // 등록
     canvas.addEventListener('mousedown', onMouseDown)
     window.addEventListener('mousemove', onMouseMove)
     window.addEventListener('mouseup', onMouseUp)
     canvas.addEventListener('wheel', onWheel, { passive: false })
+    canvas.addEventListener('contextmenu', onContextMenu)
     canvas.addEventListener('touchstart', onTouchStart, { passive: false })
     canvas.addEventListener('touchmove', onTouchMove, { passive: false })
     canvas.addEventListener('touchend', onTouchEnd)
@@ -169,11 +251,12 @@ export default function SpaceControls() {
       window.removeEventListener('mousemove', onMouseMove)
       window.removeEventListener('mouseup', onMouseUp)
       canvas.removeEventListener('wheel', onWheel)
+      canvas.removeEventListener('contextmenu', onContextMenu)
       canvas.removeEventListener('touchstart', onTouchStart)
       canvas.removeEventListener('touchmove', onTouchMove)
       canvas.removeEventListener('touchend', onTouchEnd)
     }
-  }, [camera, gl]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [gl]) // gl만 deps (followedRepoId는 ref로 처리)
 
   return null
 }

--- a/src/canvas/effects/BlackHoleSpiral.tsx
+++ b/src/canvas/effects/BlackHoleSpiral.tsx
@@ -1,0 +1,181 @@
+/**
+ * BlackHoleSpiral.tsx — 블랙홀 강착원반(Accretion Disk) 이펙트
+ *
+ * healthScore < 10인 별 주변에 나타나는 소용돌이 파티클 링.
+ * 7~8주차 '블랙홀 판정 데이터 수신 시 3D 스파이럴 애니메이션' 구현.
+ *
+ * 구성:
+ *  1. 내부 링 (빠른 회전, 밝은 주황): 강착 물질
+ *  2. 외부 링 (느린 회전, 붉은 잔상): 광자구
+ *  3. 중심 이벤트 호라이즌 glow (검정 구체, BackSide 발광)
+ *
+ * Star.tsx의 <group> 자식으로 위치 [0,0,0]에 배치 → 별 위치 자동 추종
+ */
+
+import { useRef, useMemo, useEffect } from 'react'
+import { useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
+
+// ── 파티클 생성 헬퍼 ─────────────────────────────────────────────────
+function buildDiskGeometry(
+  count: number,
+  innerR: number,
+  outerR: number,
+  thickness: number,
+  colorFn: (t: number) => [number, number, number],
+): { positions: Float32Array; colors: Float32Array } {
+  const positions = new Float32Array(count * 3)
+  const colors    = new Float32Array(count * 3)
+
+  for (let i = 0; i < count; i++) {
+    const t      = i / count
+    // 나선형: 각도 + 반지름이 함께 변화
+    const angle  = t * Math.PI * 6 + Math.random() * 0.4
+    const radius = innerR + (outerR - innerR) * Math.pow(Math.random(), 0.6)
+    const height = (Math.random() - 0.5) * thickness
+
+    positions[i * 3]     = Math.cos(angle) * radius
+    positions[i * 3 + 1] = height
+    positions[i * 3 + 2] = Math.sin(angle) * radius
+
+    const [r, g, b] = colorFn(t)
+    colors[i * 3]     = r
+    colors[i * 3 + 1] = g
+    colors[i * 3 + 2] = b
+  }
+
+  return { positions, colors }
+}
+
+// ── 컴포넌트 ─────────────────────────────────────────────────────────
+interface BlackHoleSpiralProps {
+  visible: boolean
+}
+
+export default function BlackHoleSpiral({ visible }: BlackHoleSpiralProps) {
+  const innerRef = useRef<THREE.Points>(null)
+  const outerRef = useRef<THREE.Points>(null)
+  const glowRef  = useRef<THREE.Mesh>(null)
+  const opacityRef = useRef(0)  // 페이드인 추적
+
+  // ── 파티클 데이터 (memo → 마운트 시 한 번만 생성) ──────────────────
+  const inner = useMemo(() =>
+    buildDiskGeometry(120, 1.2, 2.4, 0.15,
+      (t) => [1.0, 0.35 - t * 0.25, 0.0]),  // 흰→주황→적
+  [])
+
+  const outer = useMemo(() =>
+    buildDiskGeometry(80, 2.4, 4.5, 0.3,
+      (t) => [0.7 - t * 0.4, 0.05, 0.1]),   // 적→암적색
+  [])
+
+  // ── visibility 변경 시 opacity 초기화 ─────────────────────────────
+  useEffect(() => {
+    if (!visible) opacityRef.current = 0
+  }, [visible])
+
+  // ── 매 프레임 회전 + 페이드인 ────────────────────────────────────────
+  useFrame((state, delta) => {
+    if (!visible) return
+
+    // 페이드인 (0 → 1, 0.8초)
+    opacityRef.current = Math.min(opacityRef.current + delta * 1.25, 1)
+    const opacity = opacityRef.current
+
+    const t = state.clock.elapsedTime
+
+    // 내부 링: 빠른 역방향 회전
+    if (innerRef.current) {
+      innerRef.current.rotation.y = -t * 1.4
+      innerRef.current.rotation.x = Math.sin(t * 0.4) * 0.15;
+      (innerRef.current.material as THREE.PointsMaterial).opacity = opacity * 0.9
+    }
+
+    // 외부 링: 느린 순방향 회전
+    if (outerRef.current) {
+      outerRef.current.rotation.y = t * 0.6
+      outerRef.current.rotation.z = Math.cos(t * 0.3) * 0.1;
+      (outerRef.current.material as THREE.PointsMaterial).opacity = opacity * 0.5
+    }
+
+    // 이벤트 호라이즌 glow 맥동
+    if (glowRef.current) {
+      const pulse = 0.95 + Math.sin(t * 3.2) * 0.05
+      glowRef.current.scale.setScalar(pulse)
+      ;(glowRef.current.material as THREE.MeshBasicMaterial).opacity = opacity * 0.25
+    }
+  })
+
+  if (!visible) return null
+
+  return (
+    <group>
+      {/* 이벤트 호라이즌 glow */}
+      <mesh ref={glowRef}>
+        <sphereGeometry args={[1.15, 16, 16]} />
+        <meshBasicMaterial
+          color="#ff4400"
+          transparent
+          opacity={0}
+          side={THREE.BackSide}
+          depthWrite={false}
+          blending={THREE.AdditiveBlending}
+        />
+      </mesh>
+
+      {/* 내부 강착 디스크 */}
+      <points ref={innerRef}>
+        <bufferGeometry>
+          <bufferAttribute
+            attach="attributes-position"
+            count={120}
+            array={inner.positions}
+            itemSize={3}
+          />
+          <bufferAttribute
+            attach="attributes-color"
+            count={120}
+            array={inner.colors}
+            itemSize={3}
+          />
+        </bufferGeometry>
+        <pointsMaterial
+          size={0.12}
+          vertexColors
+          transparent
+          opacity={0}
+          sizeAttenuation
+          depthWrite={false}
+          blending={THREE.AdditiveBlending}
+        />
+      </points>
+
+      {/* 외부 광자구 잔상 */}
+      <points ref={outerRef}>
+        <bufferGeometry>
+          <bufferAttribute
+            attach="attributes-position"
+            count={80}
+            array={outer.positions}
+            itemSize={3}
+          />
+          <bufferAttribute
+            attach="attributes-color"
+            count={80}
+            array={outer.colors}
+            itemSize={3}
+          />
+        </bufferGeometry>
+        <pointsMaterial
+          size={0.09}
+          vertexColors
+          transparent
+          opacity={0}
+          sizeAttenuation
+          depthWrite={false}
+          blending={THREE.AdditiveBlending}
+        />
+      </points>
+    </group>
+  )
+}

--- a/src/canvas/effects/FrameMonitor.tsx
+++ b/src/canvas/effects/FrameMonitor.tsx
@@ -1,0 +1,60 @@
+/**
+ * FrameMonitor.tsx — FPS 모니터 (DEV 전용)
+ *
+ * Canvas 외부에 배치하는 순수 React 컴포넌트.
+ * requestAnimationFrame 루프로 FPS를 측정하고
+ * 1초마다 DOM을 직접 업데이트 (setState 없음 → 리렌더 최소화).
+ *
+ * PROD 빌드에서는 아무것도 렌더하지 않는다.
+ */
+
+import { useEffect, useRef } from 'react'
+
+export default function FrameMonitor() {
+  const domRef    = useRef<HTMLDivElement>(null)
+  const frameRef  = useRef(0)
+  const lastRef   = useRef(performance.now())
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return
+
+    let rafId: number
+
+    const loop = () => {
+      frameRef.current++
+      const now = performance.now()
+      const elapsed = now - lastRef.current
+
+      if (elapsed >= 1000) {
+        const fps = Math.round(frameRef.current * 1000 / elapsed)
+        if (domRef.current) {
+          domRef.current.textContent = `${fps} FPS`
+          // FPS에 따라 색상 변화
+          domRef.current.style.color =
+            fps >= 55 ? 'rgba(100,255,150,0.5)' :
+            fps >= 30 ? 'rgba(255,220,80,0.5)'  :
+                        'rgba(255,80,80,0.5)'
+        }
+        frameRef.current = 0
+        lastRef.current  = now
+      }
+
+      rafId = requestAnimationFrame(loop)
+    }
+
+    rafId = requestAnimationFrame(loop)
+    return () => cancelAnimationFrame(rafId)
+  }, [])
+
+  if (!import.meta.env.DEV) return null
+
+  return (
+    <div
+      ref={domRef}
+      className="absolute bottom-4 right-4 text-[11px] font-mono pointer-events-none"
+      style={{ color: 'rgba(100,255,150,0.5)' }}
+    >
+      -- FPS
+    </div>
+  )
+}

--- a/src/canvas/effects/MeteorEffect.tsx
+++ b/src/canvas/effects/MeteorEffect.tsx
@@ -1,0 +1,229 @@
+/**
+ * MeteorEffect.tsx — 유성(Shooting Star) 이펙트
+ *
+ * 구현:
+ *  - MAX_METEORS개 유성을 풀(pool)로 관리
+ *  - 각 유성은 랜덤 시작점에서 랜덤 방향으로 고속 이동
+ *  - 꼬리: drei의 Line 컴포넌트로 표현 (여러 포인트로 잔상)
+ *  - 헤드: 작은 밝은 구체
+ *  - Lerp로 opacity 페이드인/아웃
+ *
+ * 트리거:
+ *  - RESPAWN_INTERVAL_MS 마다 랜덤 유성 생성
+ *  - (7~8주차) 트렌딩 급등 이벤트와 연동 예정
+ */
+
+import { useRef, useMemo } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { Line } from '@react-three/drei'
+import * as THREE from 'three'
+
+// ── 상수 ──────────────────────────────────────────────────────────
+const MAX_METEORS = 4
+const METEOR_SPEED = 120          // units/s
+const TRAIL_LENGTH = 38           // 꼬리 길이 (units)
+const TRAIL_SEGMENTS = 12         // 꼬리 포인트 수
+const RESPAWN_INTERVAL_MS = 5500  // 평균 재출현 간격
+const FADE_IN_TIME = 0.15         // 페이드인 시간 (초)
+const LIFETIME = 1.8              // 유성 총 수명 (초)
+const SPAWN_RADIUS = 160          // 출현 반경
+
+interface MeteorState {
+  active: boolean
+  position: THREE.Vector3    // 현재 헤드 위치
+  direction: THREE.Vector3   // 정규화된 이동 방향
+  age: number                // 수명 (초)
+  opacity: number
+  color: string
+}
+
+// 유성 색상 팔레트
+const METEOR_COLORS = ['#ffffff', '#d0e8ff', '#ffe8d0', '#d0ffd0', '#ffd0ff']
+
+function spawnMeteor(m: MeteorState) {
+  // 랜덤 시작 위치 (화면 가장자리 근처)
+  const theta = Math.random() * Math.PI * 2
+  const phi   = Math.acos(2 * Math.random() - 1)
+  m.position.set(
+    Math.sin(phi) * Math.cos(theta) * SPAWN_RADIUS,
+    Math.sin(phi) * Math.sin(theta) * SPAWN_RADIUS,
+    (Math.random() - 0.5) * 80,
+  )
+  // 방향: 대략 중심을 향하되 약간 비틈
+  m.direction.set(
+    -m.position.x + (Math.random() - 0.5) * 60,
+    -m.position.y + (Math.random() - 0.5) * 60,
+    (Math.random() - 0.5) * 30,
+  ).normalize()
+  m.age = 0
+  m.opacity = 0
+  m.active = true
+  m.color = METEOR_COLORS[Math.floor(Math.random() * METEOR_COLORS.length)]
+}
+
+// ── 컴포넌트 ──────────────────────────────────────────────────────
+export default function MeteorEffect() {
+  // 유성 상태 풀 (ref — React 상태 아님)
+  const meteors = useRef<MeteorState[]>(
+    Array.from({ length: MAX_METEORS }, () => ({
+      active: false,
+      position:  new THREE.Vector3(),
+      direction: new THREE.Vector3(1, 0, 0),
+      age: 0,
+      opacity: 0,
+      color: '#ffffff',
+    })),
+  )
+
+  // 다음 유성 출현 예약 시각 (각 슬롯별)
+  const nextSpawn = useRef<number[]>(
+    Array.from({ length: MAX_METEORS }, (_, i) =>
+      (i * RESPAWN_INTERVAL_MS) / MAX_METEORS / 1000,
+    ),
+  )
+
+  // 꼬리 포인트를 저장하는 Buffer (슬롯별) — Line 렌더에 사용
+  // 각 슬롯: TRAIL_SEGMENTS+1 개의 Vector3
+  const trailBuffers = useRef<THREE.Vector3[][]>(
+    Array.from({ length: MAX_METEORS }, () =>
+      Array.from({ length: TRAIL_SEGMENTS + 1 }, () => new THREE.Vector3()),
+    ),
+  )
+
+  // Line 컴포넌트에 넘길 포인트 배열 (useMemo로 초기화)
+  const trailPoints = useMemo(
+    () =>
+      Array.from({ length: MAX_METEORS }, (_, i) =>
+        trailBuffers.current[i].map((v) => v.clone()),
+      ),
+    [],
+  )
+
+  // Line refs (opacity 직접 조작용)
+  const lineRefs = useRef<(THREE.Line | null)[]>(Array(MAX_METEORS).fill(null))
+  const headRefs = useRef<(THREE.Mesh | null)[]>(Array(MAX_METEORS).fill(null))
+
+  useFrame((state, delta) => {
+    const time = state.clock.elapsedTime
+
+    for (let i = 0; i < MAX_METEORS; i++) {
+      const m = meteors.current[i]
+
+      // 비활성 → 스폰 타이머 확인
+      if (!m.active) {
+        if (time >= nextSpawn.current[i]) {
+          spawnMeteor(m)
+        }
+        continue
+      }
+
+      // 수명 갱신
+      m.age += delta
+
+      // 수명 만료 → 비활성화 + 다음 스폰 예약
+      if (m.age >= LIFETIME) {
+        m.active = false
+        m.opacity = 0
+        nextSpawn.current[i] =
+          time + RESPAWN_INTERVAL_MS / 1000 * (0.5 + Math.random())
+
+        // 꼬리 숨기기
+        if (lineRefs.current[i]) {
+          const mat = (lineRefs.current[i] as THREE.Line).material as THREE.LineBasicMaterial
+          mat.opacity = 0
+        }
+        if (headRefs.current[i]) {
+          headRefs.current[i]!.visible = false
+        }
+        continue
+      }
+
+      // 위치 이동
+      m.position.addScaledVector(m.direction, METEOR_SPEED * delta)
+
+      // 페이드인/아웃 (Lerp)
+      const lifeRatio = m.age / LIFETIME
+      let targetOpacity: number
+      if (lifeRatio < FADE_IN_TIME / LIFETIME) {
+        targetOpacity = lifeRatio / (FADE_IN_TIME / LIFETIME)
+      } else if (lifeRatio > 0.6) {
+        targetOpacity = 1 - (lifeRatio - 0.6) / 0.4
+      } else {
+        targetOpacity = 1
+      }
+      m.opacity += (targetOpacity - m.opacity) * Math.min(delta * 12, 1)
+
+      // ── 꼬리 포인트 계산 ─────────────────────────────────────────
+      const buf = trailBuffers.current[i]
+      const tPts = trailPoints[i]
+      for (let s = 0; s <= TRAIL_SEGMENTS; s++) {
+        const t = s / TRAIL_SEGMENTS
+        buf[s].copy(m.position).addScaledVector(m.direction, -TRAIL_LENGTH * t)
+        tPts[s].copy(buf[s])
+      }
+
+      // ── Line 머티리얼 업데이트 ────────────────────────────────────
+      const line = lineRefs.current[i]
+      if (line) {
+        const mat = line.material as THREE.LineBasicMaterial
+        mat.opacity = m.opacity
+        mat.color.set(m.color)
+        // 꼬리 geometry 업데이트
+        const geo = line.geometry as THREE.BufferGeometry
+        const posAttr = geo.getAttribute('position') as THREE.BufferAttribute
+        for (let s = 0; s <= TRAIL_SEGMENTS; s++) {
+          posAttr.setXYZ(s, tPts[s].x, tPts[s].y, tPts[s].z)
+        }
+        posAttr.needsUpdate = true
+        line.visible = true
+      }
+
+      // ── 헤드(밝은 구체) 위치 ─────────────────────────────────────
+      const head = headRefs.current[i]
+      if (head) {
+        head.position.copy(m.position)
+        head.visible = true
+        const mat = head.material as THREE.MeshBasicMaterial
+        mat.opacity = m.opacity
+        mat.color.set(m.color)
+      }
+    }
+  })
+
+  return (
+    <group>
+      {Array.from({ length: MAX_METEORS }, (_, i) => (
+        <group key={i}>
+          {/* 유성 꼬리 */}
+          <Line
+            ref={(ref) => {
+              lineRefs.current[i] = ref as THREE.Line | null
+            }}
+            points={trailPoints[i]}
+            color="#ffffff"
+            lineWidth={1.2}
+            transparent
+            opacity={0}
+            visible={false}
+            vertexColors={false}
+          />
+
+          {/* 유성 헤드 */}
+          <mesh
+            ref={(ref) => {
+              headRefs.current[i] = ref as THREE.Mesh | null
+            }}
+            visible={false}
+          >
+            <sphereGeometry args={[0.7, 6, 6]} />
+            <meshBasicMaterial
+              color="#ffffff"
+              transparent
+              opacity={0}
+            />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  )
+}

--- a/src/canvas/objects/Cluster.tsx
+++ b/src/canvas/objects/Cluster.tsx
@@ -1,0 +1,181 @@
+/**
+ * Cluster.tsx — 언어별 성단(Star Cluster) 시각화
+ *
+ * v2 기능:
+ *  1. physicsStore centroid 추적: 라벨이 실제 별들의 무게중심으로 이동
+ *  2. 밀도 감지 glow: 별들이 뭉칠수록 성단 배경이 밝아짐
+ *     - avgDist(별↔중심 평균거리)를 계산 → AdditiveBlending 구체의 opacity 조절
+ *  3. 레이어드 glow: 외부 헤일로 + 내부 코어 두 겹
+ *
+ * 구성:
+ *  1. 외부 헤일로 glow (BackSide + AdditiveBlending)
+ *  2. 내부 코어 glow (DoubleSide + AdditiveBlending, 밀도 반응)
+ *  3. Sparkles 파티클 (drei)
+ *  4. Billboard 언어 라벨
+ */
+
+import { useRef } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { Sparkles, Billboard, Text } from '@react-three/drei'
+import { BackSide, DoubleSide, AdditiveBlending, MeshBasicMaterial } from 'three'
+import type { Group } from 'three'
+import { physicsStore } from '@/store/physicsStore'
+import { getBaseCenter } from '@/utils/physics'
+
+// ── 언어별 시각 설정 ──────────────────────────────────────────────
+interface ClusterStyle {
+  color: string
+  glowColor: string
+  coreColor: string
+  sparkleCount: number
+  sparkleScale: number
+  sparkleSize: number
+  glowRadius: number
+  haloOpacity: number   // 외부 헤일로 기본 opacity
+  coreOpacity: number   // 내부 코어 기본 opacity (밀도 따라 추가됨)
+}
+
+const CLUSTER_STYLES: Record<string, ClusterStyle> = {
+  TypeScript: { color: '#6ab4ff', glowColor: '#1a3a8f', coreColor: '#4488ff', sparkleCount: 60, sparkleScale: 26, sparkleSize: 1.4, glowRadius: 28, haloOpacity: 0.10, coreOpacity: 0.06 },
+  JavaScript: { color: '#ffe080', glowColor: '#4a3800', coreColor: '#ffcc40', sparkleCount: 55, sparkleScale: 30, sparkleSize: 1.3, glowRadius: 32, haloOpacity: 0.09, coreOpacity: 0.05 },
+  Python:     { color: '#a0d8ff', glowColor: '#003366', coreColor: '#60b8ff', sparkleCount: 120,sparkleScale: 22, sparkleSize: 0.9, glowRadius: 25, haloOpacity: 0.16, coreOpacity: 0.10 },
+  Go:         { color: '#00e8d0', glowColor: '#003830', coreColor: '#00c8b0', sparkleCount: 50, sparkleScale: 32, sparkleSize: 1.2, glowRadius: 34, haloOpacity: 0.09, coreOpacity: 0.05 },
+  Rust:       { color: '#ff9060', glowColor: '#4a1500', coreColor: '#ff6830', sparkleCount: 50, sparkleScale: 28, sparkleSize: 1.3, glowRadius: 30, haloOpacity: 0.10, coreOpacity: 0.06 },
+  Java:       { color: '#f0c060', glowColor: '#3a2800', coreColor: '#e0a030', sparkleCount: 45, sparkleScale: 26, sparkleSize: 1.2, glowRadius: 28, haloOpacity: 0.09, coreOpacity: 0.05 },
+  'C++':      { color: '#ff80a0', glowColor: '#3a0020', coreColor: '#ff5080', sparkleCount: 40, sparkleScale: 30, sparkleSize: 1.1, glowRadius: 32, haloOpacity: 0.09, coreOpacity: 0.05 },
+  Ruby:       { color: '#ff6060', glowColor: '#3a0000', coreColor: '#ff3030', sparkleCount: 35, sparkleScale: 26, sparkleSize: 1.2, glowRadius: 28, haloOpacity: 0.09, coreOpacity: 0.05 },
+  Swift:      { color: '#ff8844', glowColor: '#3a1500', coreColor: '#ff6820', sparkleCount: 30, sparkleScale: 24, sparkleSize: 1.3, glowRadius: 26, haloOpacity: 0.09, coreOpacity: 0.05 },
+}
+const DEFAULT_STYLE: ClusterStyle = {
+  color: '#8888cc', glowColor: '#111133', coreColor: '#6666aa',
+  sparkleCount: 35, sparkleScale: 24, sparkleSize: 1.1,
+  glowRadius: 26, haloOpacity: 0.07, coreOpacity: 0.04,
+}
+
+function getStyle(language: string): ClusterStyle {
+  return CLUSTER_STYLES[language] ?? DEFAULT_STYLE
+}
+
+// ── 컴포넌트 ──────────────────────────────────────────────────────
+interface ClusterProps {
+  language: string
+  starCount: number
+}
+
+export default function Cluster({ language, starCount }: ClusterProps) {
+  const groupRef     = useRef<Group>(null)
+  const haloMatRef   = useRef<MeshBasicMaterial>(null)
+  const coreMatRef   = useRef<MeshBasicMaterial>(null)
+  const style        = getStyle(language)
+  const sizeMult     = Math.sqrt(starCount / 8)
+
+  // ── physicsStore centroid 추적 + 밀도 glow ──────────────────────
+  useFrame(() => {
+    if (!groupRef.current) return
+
+    const entries = physicsStore.getAll().filter((e) => e.language === language)
+
+    if (entries.length > 0) {
+      // 1. 무게중심 계산
+      let cx = 0, cy = 0, cz = 0
+      for (const e of entries) {
+        cx += e.position.x
+        cy += e.position.y
+        cz += e.position.z
+      }
+      const n = entries.length
+      cx /= n; cy /= n; cz /= n
+      groupRef.current.position.set(cx, cy, cz)
+
+      // 2. 밀도 계산: 중심으로부터의 평균 거리
+      let totalDist = 0
+      for (const e of entries) {
+        const dx = e.position.x - cx
+        const dy = e.position.y - cy
+        const dz = e.position.z - cz
+        totalDist += Math.sqrt(dx * dx + dy * dy + dz * dz)
+      }
+      const avgDist = entries.length > 1 ? totalDist / entries.length : 999
+
+      // 3. 밀도 비율 (avgDist 작을수록 뭉쳐 있음)
+      const density = Math.max(0, Math.min(1, 1 - avgDist / 55))
+
+      // 4. glow opacity 업데이트 (매 프레임 lerp로 부드럽게)
+      if (haloMatRef.current) {
+        const targetHalo = style.haloOpacity + density * 0.18
+        haloMatRef.current.opacity +=
+          (targetHalo - haloMatRef.current.opacity) * 0.04
+      }
+      if (coreMatRef.current) {
+        const targetCore = style.coreOpacity + density * 0.14
+        coreMatRef.current.opacity +=
+          (targetCore - coreMatRef.current.opacity) * 0.04
+      }
+    } else {
+      // 별이 없을 때 fallback
+      const [bx, by, bz] = getBaseCenter(language)
+      groupRef.current.position.set(bx, by, bz)
+    }
+  })
+
+  return (
+    <group ref={groupRef}>
+      {/* 1. 외부 헤일로 glow (BackSide + AdditiveBlending) */}
+      <mesh>
+        <sphereGeometry args={[style.glowRadius * sizeMult, 16, 16]} />
+        {/* @ts-ignore – ref로 imperative 제어 */}
+        <meshBasicMaterial
+          ref={haloMatRef}
+          color={style.glowColor}
+          transparent
+          opacity={style.haloOpacity}
+          side={BackSide}
+          blending={AdditiveBlending}
+          depthWrite={false}
+        />
+      </mesh>
+
+      {/* 2. 내부 코어 glow (DoubleSide + AdditiveBlending, 밀도 반응) */}
+      <mesh>
+        <sphereGeometry args={[style.glowRadius * sizeMult * 0.45, 12, 12]} />
+        {/* @ts-ignore – ref로 imperative 제어 */}
+        <meshBasicMaterial
+          ref={coreMatRef}
+          color={style.coreColor}
+          transparent
+          opacity={style.coreOpacity}
+          side={DoubleSide}
+          blending={AdditiveBlending}
+          depthWrite={false}
+        />
+      </mesh>
+
+      {/* 3. 성단 분위기 입자 (drei Sparkles) */}
+      <Sparkles
+        count={Math.round(style.sparkleCount * sizeMult)}
+        scale={style.sparkleScale * sizeMult}
+        size={style.sparkleSize}
+        speed={0.25}
+        opacity={0.55}
+        color={style.color}
+        noise={0.6}
+      />
+
+      {/* 4. 언어 라벨 (항상 카메라를 향하는 Billboard) */}
+      <Billboard follow position={[0, -(style.glowRadius * sizeMult + 6), 0]}>
+        <Text
+          fontSize={5.5}
+          color={style.color}
+          anchorX="center"
+          anchorY="middle"
+          fillOpacity={0.75}
+          outlineWidth={0.5}
+          outlineColor="#000000"
+          outlineOpacity={0.65}
+        >
+          {language}
+        </Text>
+      </Billboard>
+    </group>
+  )
+}

--- a/src/canvas/objects/Star.tsx
+++ b/src/canvas/objects/Star.tsx
@@ -1,30 +1,32 @@
 /**
- * Star.tsx — 저장소 하나를 3D 별로 표현
+ * Star.tsx — 저장소 하나를 3D 별(★)로 표현
  *
- * [물리 연동]
- *  - mount 시 physicsStore.register() → physicsStore.setMesh()
- *  - usePhysics(Scene 내)가 매 프레임 mesh.position을 직접 갱신
- *  - React 리렌더 없이 위치 변경 → 최적 성능
+ * [물리 연동 — 핵심 주의사항]
+ *  - <group>에 position prop을 전달하지 않는다.
+ *    R3F는 리렌더 시 position prop을 group.position.set()으로 다시 적용하므로
+ *    물리 계산 결과를 덮어쓰게 된다 → 별이 제자리에 고정되는 버그 발생.
+ *  - 대신 useEffect에서 groupRef.current.position.copy()로 초기 위치를 딱 한 번 세팅.
+ *  - 이후 매 프레임 usePhysics가 e.object.position.copy(e.position)으로 갱신한다.
  *
- * [점수 → 시각 바인딩]
- *  - Zustand scores[repoId] 구독 (해당 별만 리렌더)
- *  - useFrame 내 Lerp로 크기·밝기 부드럽게 전환
- *
- * [페이드인]
- *  - 최초 마운트 시 scale 0 → 목표값으로 1.5초에 걸쳐 페이드인
+ * [별 모양]
+ *  - 구체 → 5각별 ExtrudeGeometry로 교체
+ *  - scale로 크기 제어 (점수 → 반지름 lerp)
+ *  - Y + Z 다중축 자전 (별마다 다른 속도)
  *
  * [블랙홀]
- *  - healthScore < 10 → 검정 + 빠른 자전 + scale 살짝 수축
+ *  - healthScore < 10 → 검정 + 빠른 자전 + BlackHoleSpiral 이펙트
  */
 
 import { useRef, useEffect, useMemo } from 'react'
 import { useFrame } from '@react-three/fiber'
-import type { Mesh, MeshStandardMaterial } from 'three'
+import * as THREE from 'three'
+import type { Group, Mesh, MeshStandardMaterial } from 'three'
 import type { StarProps } from '@/types/canvas'
 import { useGalaxyStore } from '@/store/useGalaxyStore'
 import { useUIStore } from '@/store/useUIStore'
 import { physicsStore } from '@/store/physicsStore'
 import { scoreToRadius, scoreToEmissiveIntensity } from '@/utils/physics'
+import BlackHoleSpiral from '@/canvas/effects/BlackHoleSpiral'
 
 // ── 언어 → 색상 ───────────────────────────────────────────────────
 const LANGUAGE_COLORS: Record<string, string> = {
@@ -49,10 +51,49 @@ function getColor(language: string | null) {
   return language ? (LANGUAGE_COLORS[language] ?? DEFAULT_COLOR) : DEFAULT_COLOR
 }
 
+// ── 5각별 ExtrudeGeometry 생성 ────────────────────────────────────
+function createStarGeometry(): THREE.ExtrudeGeometry {
+  const outerR = 1.0
+  const innerR = 0.40
+  const pts   = 5
+  const step  = (Math.PI * 2) / pts
+
+  const shape = new THREE.Shape()
+  for (let i = 0; i < pts; i++) {
+    const oa = i * step - Math.PI / 2
+    const ia = oa + step / 2
+    const ox = Math.cos(oa) * outerR, oy = Math.sin(oa) * outerR
+    const ix = Math.cos(ia) * innerR, iy = Math.sin(ia) * innerR
+    if (i === 0) shape.moveTo(ox, oy)
+    else         shape.lineTo(ox, oy)
+    shape.lineTo(ix, iy)
+  }
+  shape.closePath()
+
+  const depth = 0.30
+  const geo = new THREE.ExtrudeGeometry(shape, {
+    depth,
+    bevelEnabled:   true,
+    bevelThickness: 0.07,
+    bevelSize:      0.05,
+    bevelSegments:  2,
+  })
+  // Z축 중앙 정렬 (기본: z=0~depth → 중심으로)
+  geo.translate(0, 0, -depth / 2)
+  return geo
+}
+
+// ── 앱 전체에서 공유되는 단일 별 지오메트리 ──────────────────────
+const SHARED_STAR_GEO = createStarGeometry()
+
 // ─────────────────────────────────────────────────────────────────
 export default function Star({ repoId, name, position, language, onClick }: StarProps) {
-  const meshRef = useRef<Mesh>(null)
-  const matRef  = useRef<MeshStandardMaterial>(null)
+  const groupRef = useRef<Group>(null)
+  const meshRef  = useRef<Mesh>(null)
+  const matRef   = useRef<MeshStandardMaterial>(null)
+
+  // ── 별마다 다른 자전 속도 (repoId 기반 고정값) ──────────────────
+  const rotSpeed = useMemo(() => 0.5 + (repoId % 17) * 0.035, [repoId])
 
   // ── Zustand 점수 구독 (이 repoId만 선택적 리렌더) ───────────────
   const score         = useGalaxyStore((s) => s.scores[repoId])
@@ -68,9 +109,9 @@ export default function Star({ repoId, name, position, language, onClick }: Star
   const color          = useMemo(() => isBlackHole ? '#050508' : getColor(language), [isBlackHole, language])
 
   // ── Lerp용 현재값 ref (React 상태 아님 → 리렌더 없이 갱신) ──────
-  const curRadius   = useRef(0)       // 0에서 시작 → 페이드인
+  const curRadius   = useRef(0)
   const curEmissive = useRef(0)
-  const fadeAge     = useRef(0)       // 마운트 후 경과 시간 (초)
+  const fadeAge     = useRef(0)
   const hoveredRef  = useRef(false)
 
   // ── physicsStore 등록 ─────────────────────────────────────────────
@@ -79,79 +120,99 @@ export default function Star({ repoId, name, position, language, onClick }: Star
     return () => physicsStore.unregister(repoId)
   }, [repoId]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // mesh ref가 준비된 후 physicsStore에 연결
+  // ── group ref 연결 + 초기 위치 세팅 (R3F prop 대신 명시적 세팅) ──
+  // position prop을 JSX에 넘기지 않는 이유:
+  //   R3F는 리렌더마다 prop을 group.position.set()으로 재적용 →
+  //   물리 계산 결과(매 프레임 갱신)를 덮어써서 별이 제자리에 고정되는 버그.
   useEffect(() => {
-    if (meshRef.current) physicsStore.setMesh(repoId, meshRef.current)
+    if (!groupRef.current) return
+    const entry = physicsStore.entries.get(repoId)
+    if (entry) {
+      // physicsStore에 저장된 초기 위치를 Three.js 오브젝트에 직접 복사
+      groupRef.current.position.copy(entry.position)
+    }
+    // 이후 매 프레임 usePhysics가 이 오브젝트 position을 갱신함
+    physicsStore.setObject(repoId, groupRef.current)
   }, [repoId])
 
-  // ── 매 프레임: Lerp 갱신 (크기·밝기·페이드인) ──────────────────
+  // ── 매 프레임: Lerp 갱신 (크기·밝기·페이드인·자전) ─────────────
   useFrame((_, delta) => {
     if (!meshRef.current || !matRef.current) return
 
     // 페이드인: 마운트 후 1.5초에 걸쳐 0 → 1
     const prevAge = fadeAge.current
     fadeAge.current = Math.min(fadeAge.current + delta, 1.5)
-    const fadeT = fadeAge.current / 1.5          // 0 → 1
-    const justAppeared = prevAge < 1.5            // 아직 페이드인 중
+    const fadeT      = fadeAge.current / 1.5
+    const fadingIn   = prevAge < 1.5
 
-    // Lerp 속도: 점수가 크게 변할수록 빠르게 반응
+    // Lerp 속도
     const speed = 3.5 * delta
-
     curRadius.current   += (targetRadius   - curRadius.current)   * speed
     curEmissive.current += (targetEmissive - curEmissive.current) * speed
 
     // 스케일 = Lerp 반지름 × hover 배율 × 페이드인
-    const hoverMult = hoveredRef.current ? 1.35 : 1.0
-    const finalScale = curRadius.current * hoverMult * (justAppeared ? fadeT : 1)
+    const hoverMult  = hoveredRef.current ? 1.35 : 1.0
+    const finalScale = curRadius.current * hoverMult * (fadingIn ? fadeT : 1)
     meshRef.current.scale.setScalar(Math.max(0, finalScale))
 
     // emissive 강도
     matRef.current.emissiveIntensity =
-      curEmissive.current * (hoveredRef.current ? 2.0 : 1.0) * (justAppeared ? fadeT : 1)
-    matRef.current.opacity = justAppeared ? fadeT : 1
+      curEmissive.current * (hoveredRef.current ? 2.0 : 1.0) * (fadingIn ? fadeT : 1)
+    matRef.current.opacity = fadingIn ? fadeT : 1
 
-    // 자전 (블랙홀은 빠르게)
-    meshRef.current.rotation.y += delta * (isBlackHole ? 1.2 : 0.18)
-    if (isBlackHole) meshRef.current.rotation.z += delta * 0.5
+    // ── 다중축 자전 (블랙홀은 빠르게) ────────────────────────────
+    const speedMult = isBlackHole ? 4.0 : 1.0
+    meshRef.current.rotation.y += delta * rotSpeed * speedMult * 0.14
+    meshRef.current.rotation.z += delta * rotSpeed * speedMult * 0.07
+    if (isBlackHole) {
+      meshRef.current.rotation.x += delta * 0.4
+    }
   })
 
   return (
-    <mesh
-      ref={meshRef}
-      // position은 초기값만 — physicsStore/usePhysics가 매 프레임 덮어씀
-      position={position}
-      onPointerOver={(e) => {
-        e.stopPropagation()
-        hoveredRef.current = true
-        setHovered(repoId)
-        document.body.style.cursor = 'pointer'
-      }}
-      onPointerOut={() => {
-        hoveredRef.current = false
-        setHovered(null)
-        document.body.style.cursor = 'grab'
-      }}
-      onClick={(e) => {
-        e.stopPropagation()
-        selectRepo(repoId)
-        onClick?.(repoId)
-        if (import.meta.env.DEV) {
-          console.log(`[Star] ${name} | activity=${activityScore} health=${healthScore}${isBlackHole ? ' 🕳️ 블랙홀' : ''}`)
-        }
-      }}
-    >
-      {/* 반지름 1 고정, scale로 크기 제어 */}
-      <sphereGeometry args={[1, 16, 16]} />
-      <meshStandardMaterial
-        ref={matRef}
-        color={color}
-        emissive={isBlackHole ? '#000000' : color}
-        emissiveIntensity={targetEmissive}
-        roughness={isBlackHole ? 1.0 : 0.3}
-        metalness={isBlackHole ? 0.0 : 0.1}
-        transparent
-        opacity={1}
-      />
-    </mesh>
+    // position prop 없음 — useEffect에서 명시적으로 세팅
+    <group ref={groupRef}>
+      {/* ── 5각별 메시 ───────────────────────────────────────────── */}
+      <mesh
+        ref={meshRef}
+        geometry={SHARED_STAR_GEO}
+        onPointerOver={(e) => {
+          e.stopPropagation()
+          hoveredRef.current = true
+          setHovered(repoId)
+          document.body.style.cursor = 'pointer'
+        }}
+        onPointerOut={() => {
+          hoveredRef.current = false
+          setHovered(null)
+          document.body.style.cursor = 'grab'
+        }}
+        onClick={(e) => {
+          e.stopPropagation()
+          selectRepo(repoId)
+          onClick?.(repoId)
+          if (import.meta.env.DEV) {
+            console.log(
+              `[Star] ${name} | activity=${activityScore} health=${healthScore}` +
+              (isBlackHole ? ' 🕳️ 블랙홀' : ''),
+            )
+          }
+        }}
+      >
+        <meshStandardMaterial
+          ref={matRef}
+          color={color}
+          emissive={isBlackHole ? '#000000' : color}
+          emissiveIntensity={targetEmissive}
+          roughness={isBlackHole ? 1.0 : 0.25}
+          metalness={isBlackHole ? 0.0  : 0.35}
+          transparent
+          opacity={1}
+        />
+      </mesh>
+
+      {/* ── 블랙홀 강착원반 이펙트 ──────────────────────────────────── */}
+      <BlackHoleSpiral visible={isBlackHole} />
+    </group>
   )
 }

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,31 @@
+/**
+ * LoadingSpinner.tsx — 공통 로딩 스피너
+ * Tailwind 애니메이션 기반, size prop으로 크기 조절 가능
+ */
+
+interface Props {
+  size?: 'sm' | 'md' | 'lg'
+  color?: string   // Tailwind color class (e.g. 'border-blue-400')
+}
+
+const sizeMap = {
+  sm: 'w-4 h-4 border-2',
+  md: 'w-6 h-6 border-2',
+  lg: 'w-8 h-8 border-[3px]',
+}
+
+export default function LoadingSpinner({ size = 'md', color = 'border-blue-400' }: Props) {
+  return (
+    <div
+      className={`
+        ${sizeMap[size]}
+        ${color}
+        rounded-full
+        border-t-transparent
+        animate-spin
+      `}
+      role="status"
+      aria-label="로딩 중"
+    />
+  )
+}

--- a/src/components/overlay/HelpOverlay.tsx
+++ b/src/components/overlay/HelpOverlay.tsx
@@ -1,0 +1,70 @@
+/**
+ * HelpOverlay.tsx — 도움말 오버레이
+ *
+ * 화면 우하단의 ? 버튼으로 토글.
+ * 카메라 조작 방법 및 별 인터랙션 설명.
+ */
+
+import { useState } from 'react'
+
+interface HelpItem {
+  icon: string
+  action: string
+  desc: string
+}
+
+const HELP_ITEMS: HelpItem[] = [
+  { icon: '🖱️', action: '드래그',       desc: '우주 공간 이동' },
+  { icon: '⚙️', action: '스크롤',       desc: '줌인 / 줌아웃' },
+  { icon: '👆', action: '별 클릭',     desc: '상세 정보 패널 열기' },
+  { icon: '✨', action: '별 호버',     desc: '저장소 미리보기' },
+  { icon: '🌌', action: '각 성단',     desc: '같은 언어의 별 모음' },
+  { icon: '🕳️', action: '검은 별',    desc: '건강 지수 위험 (블랙홀)' },
+  { icon: '☄️', action: '유성',        desc: '실시간 저장소 이벤트' },
+]
+
+export default function HelpOverlay() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="absolute bottom-6 right-4 z-20 font-mono select-none">
+      {/* 도움말 패널 */}
+      {open && (
+        <div className="mb-2 bg-space-900/95 border border-white/10 rounded-xl px-4 py-3 shadow-2xl backdrop-blur-sm w-56 text-[11px]">
+          <p className="text-white/50 uppercase tracking-widest text-[9px] mb-3">사용 방법</p>
+          <ul className="space-y-2">
+            {HELP_ITEMS.map(({ icon, action, desc }) => (
+              <li key={action} className="flex items-start gap-2">
+                <span className="text-base leading-none mt-0.5">{icon}</span>
+                <div>
+                  <span className="text-white/80 font-semibold">{action}</span>
+                  <span className="text-white/40"> — {desc}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-3 pt-2.5 border-t border-white/5 text-[9px] text-white/25 leading-relaxed">
+            GitHub Universe — 오픈소스 생태계 실시간 3D 시각화<br />
+            별 크기 = 활동량 · 밝기 = 건강 지수
+          </div>
+        </div>
+      )}
+
+      {/* 토글 버튼 */}
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className={`
+          w-8 h-8 rounded-full flex items-center justify-center
+          text-sm font-bold border transition-all duration-200 ml-auto
+          ${open
+            ? 'bg-white/20 border-white/30 text-white'
+            : 'bg-black/40 border-white/10 text-white/40 hover:text-white/70 hover:border-white/20'
+          }
+        `}
+        aria-label="도움말 토글"
+      >
+        ?
+      </button>
+    </div>
+  )
+}

--- a/src/components/overlay/Legend.tsx
+++ b/src/components/overlay/Legend.tsx
@@ -1,0 +1,59 @@
+/**
+ * Legend.tsx — 언어별 색상 범례
+ *
+ * 화면 하단 좌측에 고정 배치.
+ * 현재 씬에 존재하는 언어만 표시 (없는 언어는 숨김).
+ * 토글 버튼으로 접기/펼치기 가능.
+ */
+
+import { useState } from 'react'
+import { useGalaxyStore } from '@/store/useGalaxyStore'
+
+const LANGUAGE_COLORS: Record<string, string> = {
+  TypeScript: '#4f8ef7', JavaScript: '#f7d44f', Python:    '#4da8e0',
+  Go:         '#00d4c8', Rust:       '#f07050', Java:      '#e8a24a',
+  'C++':      '#e05080', Ruby:       '#d94040', Swift:     '#f05c30',
+  Kotlin:     '#b06cff', PHP:        '#9090e0', 'C#':      '#68c060',
+  Scala:      '#d04040', Haskell:    '#9060c8',
+}
+
+export default function Legend() {
+  const [collapsed, setCollapsed] = useState(false)
+  const stars = useGalaxyStore((s) => s.stars)
+
+  // 씬에 존재하는 언어만 추출 (순서 유지)
+  const languages = Array.from(
+    new Set(stars.map((s) => s.language).filter(Boolean) as string[])
+  )
+
+  if (languages.length === 0) return null
+
+  return (
+    <div className="absolute bottom-6 left-4 z-20 font-mono text-[11px] select-none">
+      {/* 헤더 */}
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex items-center gap-1.5 text-white/40 hover:text-white/70 transition-colors mb-1.5"
+        aria-label={collapsed ? '범례 펼치기' : '범례 접기'}
+      >
+        <span className="text-[10px]">{collapsed ? '▶' : '▼'}</span>
+        <span className="tracking-widest uppercase text-[9px]">Legend</span>
+      </button>
+
+      {/* 언어 목록 */}
+      {!collapsed && (
+        <ul className="space-y-1.5 bg-black/30 backdrop-blur-sm rounded-lg px-2.5 py-2 border border-white/5">
+          {languages.map((lang) => (
+            <li key={lang} className="flex items-center gap-2">
+              <span
+                className="w-2 h-2 rounded-full flex-shrink-0"
+                style={{ backgroundColor: LANGUAGE_COLORS[lang] ?? '#aabbcc', boxShadow: `0 0 4px ${LANGUAGE_COLORS[lang] ?? '#aabbcc'}80` }}
+              />
+              <span className="text-white/60 text-[10px]">{lang}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/overlay/LoginButton.tsx
+++ b/src/components/overlay/LoginButton.tsx
@@ -1,0 +1,47 @@
+/**
+ * LoginButton.tsx — GitHub OAuth 로그인 버튼 (9~10주차)
+ *
+ * 동작:
+ *  - 비로그인: GitHub 로그인 버튼 표시
+ *    → 클릭 시 BE OAuth 엔드포인트로 리디렉션
+ *  - 로그인 중: 프로필 이미지 + 유저명 표시
+ *    → 클릭 시 프로필/설정 모달 열기 예정 (TODO)
+ *
+ * BE 연동:
+ *  - GET /oauth2/authorization/github  → GitHub OAuth 시작
+ *  - 콜백 후 GET /api/users/me         → 유저 정보 수신
+ */
+
+import { useUIStore } from '@/store/useUIStore'
+
+const OAUTH_URL = `${import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'}/oauth2/authorization/github`
+
+export default function LoginButton() {
+  const user = useUIStore((s) => s.user)
+
+  if (user) {
+    return (
+      <div className="absolute top-4 right-4 z-20 flex items-center gap-2 bg-black/40 backdrop-blur-sm border border-white/10 rounded-full px-3 py-1.5 cursor-pointer hover:bg-black/60 transition-all">
+        <img
+          src={user.profileImageUrl}
+          alt={user.username}
+          className="w-6 h-6 rounded-full"
+        />
+        <span className="text-[11px] font-mono text-white/70">{user.username}</span>
+      </div>
+    )
+  }
+
+  return (
+    <a
+      href={OAUTH_URL}
+      className="absolute top-4 right-4 z-20 flex items-center gap-2 bg-white/8 hover:bg-white/14 border border-white/10 rounded-full px-3 py-1.5 transition-all duration-150 group no-underline"
+    >
+      {/* GitHub 아이콘 (SVG) */}
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" className="text-white/50 group-hover:text-white/80">
+        <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+      </svg>
+      <span className="text-[11px] font-mono text-white/50 group-hover:text-white/80">GitHub 로그인</span>
+    </a>
+  )
+}

--- a/src/components/overlay/Tooltip.tsx
+++ b/src/components/overlay/Tooltip.tsx
@@ -1,0 +1,151 @@
+/**
+ * Tooltip.tsx — 별 마우스오버 시 나타나는 2D 툴팁
+ *
+ * 동작:
+ *  - useUIStore.hoveredRepoId를 구독
+ *  - 전역 mousemove 이벤트로 커서 위치 추적 (ref 사용 → 리렌더 없음)
+ *  - hoveredRepoId 변경 시만 React 리렌더
+ *
+ * 표시 내용:
+ *  - 저장소 이름, 언어 (색상 닷), 활동 점수, 건강 점수, 트렌드
+ */
+
+import { useEffect, useRef, useCallback } from 'react'
+import { useUIStore } from '@/store/useUIStore'
+import { useGalaxyStore } from '@/store/useGalaxyStore'
+import { formatCount } from '@/utils/format'
+
+// ── 언어별 색상 (Star.tsx와 동기화) ─────────────────────────────────
+const LANGUAGE_COLORS: Record<string, string> = {
+  TypeScript: '#4f8ef7', JavaScript: '#f7d44f', Python: '#4da8e0',
+  Go: '#00d4c8',  Rust: '#f07050',   Java: '#e8a24a',
+  'C++': '#e05080', Ruby: '#d94040', Swift: '#f05c30',
+  Kotlin: '#b06cff', PHP: '#9090e0', 'C#': '#68c060',
+}
+const DEFAULT_COLOR = '#aabbcc'
+
+function trendLabel(delta: number) {
+  if (delta > 15) return { text: '🔥 급등', cls: 'text-orange-400' }
+  if (delta > 5)  return { text: '↑ 상승', cls: 'text-green-400' }
+  if (delta < -5) return { text: '↓ 하락', cls: 'text-red-400' }
+  return { text: '→ 안정', cls: 'text-gray-400' }
+}
+
+// ─────────────────────────────────────────────────────────────────
+export default function Tooltip() {
+  const tooltipRef  = useRef<HTMLDivElement>(null)
+  const posRef      = useRef({ x: 0, y: 0 })
+  const visibleRef  = useRef(false)
+  const rafRef      = useRef<number>(0)
+
+  const hoveredRepoId = useUIStore((s) => s.hoveredRepoId)
+  const repositories  = useGalaxyStore((s) => s.repositories)
+  const scores        = useGalaxyStore((s) => s.scores)
+
+  // ── 글로벌 마우스 트래킹 (ref 기반 → 리렌더 없음) ────────────────
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      posRef.current = { x: e.clientX, y: e.clientY }
+    }
+    window.addEventListener('mousemove', onMove)
+    return () => window.removeEventListener('mousemove', onMove)
+  }, [])
+
+  // ── rAF 루프로 툴팁 위치 업데이트 ────────────────────────────────
+  const syncPosition = useCallback(() => {
+    if (tooltipRef.current && visibleRef.current) {
+      const { x, y } = posRef.current
+      const el = tooltipRef.current
+      // 화면 오른쪽·아래 넘침 방지
+      const offsetX = x + 180 > window.innerWidth  ? -180 : 16
+      const offsetY = y + 120 > window.innerHeight ? -120 : 12
+      el.style.transform = `translate(${x + offsetX}px, ${y + offsetY}px)`
+    }
+    rafRef.current = requestAnimationFrame(syncPosition)
+  }, [])
+
+  useEffect(() => {
+    rafRef.current = requestAnimationFrame(syncPosition)
+    return () => cancelAnimationFrame(rafRef.current)
+  }, [syncPosition])
+
+  // ── hoveredRepoId 변경 시 visibility 토글 ────────────────────────
+  useEffect(() => {
+    visibleRef.current = hoveredRepoId !== null
+    if (tooltipRef.current) {
+      tooltipRef.current.style.opacity = hoveredRepoId !== null ? '1' : '0'
+      tooltipRef.current.style.pointerEvents = 'none'
+    }
+  }, [hoveredRepoId])
+
+  // ── 데이터 조회 ──────────────────────────────────────────────────
+  const repo  = hoveredRepoId ? repositories.find((r) => r.id === hoveredRepoId) : null
+  const score = hoveredRepoId ? scores[hoveredRepoId] : undefined
+  const langColor = repo?.language ? (LANGUAGE_COLORS[repo.language] ?? DEFAULT_COLOR) : DEFAULT_COLOR
+  const trend = score ? trendLabel(score.trendDelta) : null
+
+  return (
+    <div
+      ref={tooltipRef}
+      className="fixed top-0 left-0 z-50 pointer-events-none"
+      style={{ opacity: 0, transition: 'opacity 0.12s ease', willChange: 'transform' }}
+    >
+      {repo && (
+        <div className="bg-space-900/95 border border-white/10 rounded-lg px-3 py-2.5 shadow-2xl backdrop-blur-sm min-w-[160px]">
+          {/* 이름 */}
+          <p className="text-white text-sm font-mono font-semibold leading-tight truncate max-w-[200px]">
+            {repo.name}
+          </p>
+          <p className="text-white/40 text-[10px] font-mono truncate max-w-[200px]">
+            {repo.fullName}
+          </p>
+
+          {/* 언어 */}
+          {repo.language && (
+            <div className="flex items-center gap-1.5 mt-1.5">
+              <span
+                className="w-2 h-2 rounded-full flex-shrink-0"
+                style={{ backgroundColor: langColor }}
+              />
+              <span className="text-[11px] text-white/70 font-mono">{repo.language}</span>
+            </div>
+          )}
+
+          {/* 점수 */}
+          {score && (
+            <div className="mt-2 flex gap-3">
+              <div className="text-center">
+                <p className="text-[10px] text-white/40 font-mono">활동</p>
+                <p className="text-xs text-blue-300 font-mono font-bold">{score.activityScore}</p>
+              </div>
+              <div className="text-center">
+                <p className="text-[10px] text-white/40 font-mono">건강</p>
+                <p
+                  className={`text-xs font-mono font-bold ${score.healthScore < 10 ? 'text-red-400' : score.healthScore < 40 ? 'text-orange-400' : 'text-green-400'}`}
+                >
+                  {score.healthScore}
+                </p>
+              </div>
+              <div className="text-center">
+                <p className="text-[10px] text-white/40 font-mono">Stars</p>
+                <p className="text-xs text-yellow-300 font-mono font-bold">{formatCount(repo.starCount)}</p>
+              </div>
+            </div>
+          )}
+
+          {/* 트렌드 */}
+          {trend && (
+            <p className={`text-[10px] font-mono mt-1.5 ${trend.cls}`}>{trend.text}</p>
+          )}
+
+          {/* 블랙홀 경고 */}
+          {score && score.healthScore < 10 && (
+            <p className="text-[10px] text-red-400 font-mono mt-1 animate-pulse">
+              ⚠ 블랙홀 전환 중
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/panel/RAGAnalysis.tsx
+++ b/src/components/panel/RAGAnalysis.tsx
@@ -1,0 +1,157 @@
+/**
+ * RAGAnalysis.tsx — RAG 기반 AI 분석 UI (7~8주차)
+ *
+ * 동작:
+ *  1. "왜 트렌딩인가?" 버튼 클릭
+ *  2. POST /api/rag/analyze 호출 (useRagAnalysis 훅)
+ *  3. 로딩 중: 스피너 + 진행 메시지
+ *  4. 완료: 분석 텍스트 + 출처 URL 목록 + 신뢰도 바
+ */
+
+import { useState } from 'react'
+import { useRagAnalysis } from '@/hooks/queries/useRagAnalysis'
+import type { RagAnalysisResponse } from '@/types/github'
+import LoadingSpinner from '@/components/common/LoadingSpinner'
+
+interface Props {
+  repoId: number
+  repoName: string
+}
+
+// ── 신뢰도 → 색상 ────────────────────────────────────────────────────
+function confidenceColor(c: number): string {
+  if (c >= 0.85) return 'bg-green-500'
+  if (c >= 0.65) return 'bg-yellow-500'
+  return 'bg-red-500'
+}
+
+// ── 마크다운 굵은글씨만 처리 ────────────────────────────────────────
+function renderAnalysis(text: string) {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g)
+  return parts.map((part, i) => {
+    if (part.startsWith('**') && part.endsWith('**')) {
+      return <strong key={i} className="text-white font-semibold">{part.slice(2, -2)}</strong>
+    }
+    // 개행 처리
+    return part.split('\n').map((line, j) => (
+      <span key={`${i}-${j}`}>{line}{j < part.split('\n').length - 1 && <br />}</span>
+    ))
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────
+export default function RAGAnalysis({ repoId, repoName }: Props) {
+  const [result, setResult] = useState<RagAnalysisResponse | null>(null)
+  const { mutate, isPending, error } = useRagAnalysis(repoName)
+
+  const handleAnalyze = () => {
+    setResult(null)
+    mutate(
+      { repoId, question: '이 저장소의 활동이 증가한 이유는 무엇인가요?' },
+      { onSuccess: (data) => setResult(data) },
+    )
+  }
+
+  return (
+    <div className="mt-4 border-t border-white/5 pt-4">
+      {/* 섹션 헤더 */}
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-[10px] text-white/40 uppercase tracking-widest font-mono">AI 분석</p>
+        {result && (
+          <button
+            onClick={handleAnalyze}
+            className="text-[9px] text-white/30 hover:text-white/60 transition-colors font-mono underline"
+          >
+            재분석
+          </button>
+        )}
+      </div>
+
+      {/* 초기 상태: 버튼 */}
+      {!result && !isPending && !error && (
+        <button
+          onClick={handleAnalyze}
+          className="w-full flex items-center justify-center gap-2 py-2.5 rounded-lg border border-white/10 bg-white/5 hover:bg-white/10 transition-all duration-150 group"
+        >
+          <span className="text-lg group-hover:scale-110 transition-transform">🤔</span>
+          <span className="text-xs font-mono text-white/60 group-hover:text-white/90">
+            왜 트렌딩인가요?
+          </span>
+        </button>
+      )}
+
+      {/* 로딩 */}
+      {isPending && (
+        <div className="flex flex-col items-center gap-2.5 py-4">
+          <LoadingSpinner size="md" color="border-purple-400" />
+          <p className="text-[11px] text-white/40 font-mono animate-pulse">
+            RAG 분석 중... 문서를 검색하고 있어요
+          </p>
+        </div>
+      )}
+
+      {/* 에러 */}
+      {error && !isPending && (
+        <div className="py-3 text-center">
+          <p className="text-xs text-red-400 font-mono mb-2">{error.message}</p>
+          <button
+            onClick={handleAnalyze}
+            className="text-[11px] text-white/40 hover:text-white/70 underline font-mono"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {/* 분석 결과 */}
+      {result && (
+        <div className="space-y-3">
+          {/* 분석 텍스트 */}
+          <div className="text-[11px] font-mono text-white/65 leading-relaxed bg-white/3 rounded-lg px-3 py-2.5 border border-white/5">
+            {renderAnalysis(result.analysis)}
+          </div>
+
+          {/* 신뢰도 */}
+          <div>
+            <div className="flex justify-between items-center mb-1">
+              <span className="text-[9px] text-white/30 font-mono uppercase tracking-wider">신뢰도</span>
+              <span className="text-[9px] text-white/50 font-mono">{Math.round(result.confidence * 100)}%</span>
+            </div>
+            <div className="h-1 bg-white/5 rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-700 ${confidenceColor(result.confidence)}`}
+                style={{ width: `${result.confidence * 100}%` }}
+              />
+            </div>
+          </div>
+
+          {/* 출처 */}
+          {result.sources.length > 0 && (
+            <div>
+              <p className="text-[9px] text-white/25 font-mono uppercase tracking-wider mb-1.5">참고 출처</p>
+              <ul className="space-y-1">
+                {result.sources.slice(0, 3).map((url, i) => (
+                  <li key={i}>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[10px] text-blue-400/70 hover:text-blue-300 font-mono truncate block underline-offset-2 hover:underline transition-colors"
+                    >
+                      {url.replace('https://', '')}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* 생성 시각 */}
+          <p className="text-[9px] text-white/20 font-mono">
+            생성: {new Date(result.generatedAt).toLocaleTimeString('ko-KR')}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/panel/ScoreChart.tsx
+++ b/src/components/panel/ScoreChart.tsx
@@ -1,0 +1,177 @@
+/**
+ * ScoreChart.tsx — 점수 타임라인 SVG 스파크라인 차트
+ *
+ * 외부 라이브러리 없이 순수 SVG로 구현.
+ * useScoreHistory 훅에서 받아온 24시간 데이터를 시각화.
+ *
+ * 두 라인:
+ *  - 파란선: activeScore (활동 지수)
+ *  - 초록선: healthScore (건강 지수)
+ */
+
+import { useMemo } from 'react'
+import type { ScoreHistoryEntry } from '@/types/github'
+
+interface Props {
+  data: ScoreHistoryEntry[]
+  height?: number
+}
+
+const W = 260
+const PADDING = { top: 4, right: 4, bottom: 18, left: 24 }
+
+function buildPath(
+  data: ScoreHistoryEntry[],
+  valueKey: 'activeScore' | 'healthScore',
+  chartW: number,
+  chartH: number,
+): string {
+  if (data.length < 2) return ''
+  return data
+    .map((entry, i) => {
+      const x = (i / (data.length - 1)) * chartW
+      const y = chartH - (entry[valueKey] / 100) * chartH
+      return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+}
+
+function buildArea(
+  data: ScoreHistoryEntry[],
+  valueKey: 'activeScore' | 'healthScore',
+  chartW: number,
+  chartH: number,
+): string {
+  if (data.length < 2) return ''
+  const linePts = data.map((entry, i) => {
+    const x = (i / (data.length - 1)) * chartW
+    const y = chartH - (entry[valueKey] / 100) * chartH
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  })
+  return `M${linePts[0]} L${linePts.join(' L')} L${chartW},${chartH} L0,${chartH} Z`
+}
+
+// 시각 포맷: 0~23 → "0h" ~ "23h"
+function bucketLabel(iso: string): string {
+  const h = new Date(iso).getHours()
+  return `${h}h`
+}
+
+export default function ScoreChart({ data, height = 80 }: Props) {
+  const chartW = W - PADDING.left - PADDING.right
+  const chartH = height - PADDING.top - PADDING.bottom
+
+  const activityPath = useMemo(() => buildPath(data, 'activeScore', chartW, chartH), [data, chartW, chartH])
+  const healthPath   = useMemo(() => buildPath(data, 'healthScore', chartW, chartH), [data, chartW, chartH])
+  const activityArea = useMemo(() => buildArea(data, 'activeScore', chartW, chartH), [data, chartW, chartH])
+
+  // X 축 레이블: 6시간 간격
+  const xLabels = useMemo(() => {
+    if (data.length === 0) return []
+    const step = Math.floor(data.length / 4)
+    return [0, step, step * 2, step * 3, data.length - 1].map((i) => ({
+      x: (i / (data.length - 1)) * chartW,
+      label: bucketLabel(data[i]?.bucket ?? ''),
+    }))
+  }, [data, chartW])
+
+  // 현재 마지막 값
+  const last = data[data.length - 1]
+
+  if (data.length === 0) {
+    return (
+      <div className="h-20 flex items-center justify-center text-white/25 text-xs font-mono">
+        데이터 없음
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <svg
+        width={W}
+        height={height}
+        viewBox={`0 0 ${W} ${height}`}
+        className="w-full overflow-visible"
+      >
+        <defs>
+          <linearGradient id="actGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#60a5fa" stopOpacity="0.25" />
+            <stop offset="100%" stopColor="#60a5fa" stopOpacity="0" />
+          </linearGradient>
+          <clipPath id="chartClip">
+            <rect x={0} y={0} width={chartW} height={chartH} />
+          </clipPath>
+        </defs>
+
+        <g transform={`translate(${PADDING.left},${PADDING.top})`}>
+          {/* Y 축 가이드라인 */}
+          {[0, 25, 50, 75, 100].map((v) => {
+            const y = chartH - (v / 100) * chartH
+            return (
+              <g key={v}>
+                <line x1={0} y1={y} x2={chartW} y2={y} stroke="rgba(255,255,255,0.04)" strokeWidth={1} />
+                <text x={-4} y={y + 3.5} textAnchor="end" fill="rgba(255,255,255,0.25)" fontSize={8} fontFamily="monospace">
+                  {v}
+                </text>
+              </g>
+            )
+          })}
+
+          {/* 활동 지수 영역 */}
+          <path d={activityArea} fill="url(#actGrad)" clipPath="url(#chartClip)" />
+
+          {/* 활동 지수 라인 */}
+          <path
+            d={activityPath}
+            fill="none"
+            stroke="#60a5fa"
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            clipPath="url(#chartClip)"
+          />
+
+          {/* 건강 지수 라인 */}
+          <path
+            d={healthPath}
+            fill="none"
+            stroke="#34d399"
+            strokeWidth={1.2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeDasharray="3 2"
+            clipPath="url(#chartClip)"
+          />
+
+          {/* X 축 레이블 */}
+          {xLabels.map(({ x, label }) => (
+            <text
+              key={label}
+              x={x}
+              y={chartH + 14}
+              textAnchor="middle"
+              fill="rgba(255,255,255,0.25)"
+              fontSize={8}
+              fontFamily="monospace"
+            >
+              {label}
+            </text>
+          ))}
+        </g>
+      </svg>
+
+      {/* 범례 */}
+      <div className="flex gap-4 mt-1 text-[10px] font-mono text-white/40">
+        <span className="flex items-center gap-1">
+          <span className="w-3 h-px bg-blue-400 inline-block" />
+          활동 {last ? last.activeScore : '--'}
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="w-3 h-px bg-emerald-400 inline-block" style={{ borderTop: '1px dashed' }} />
+          건강 {last ? last.healthScore : '--'}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/panel/SidePanel.tsx
+++ b/src/components/panel/SidePanel.tsx
@@ -1,0 +1,350 @@
+/**
+ * SidePanel.tsx — 별 클릭 시 열리는 우측 상세 정보 패널
+ *
+ * v2 변경: 리사이즈 핸들 추가
+ *  - 패널 왼쪽 가장자리에 드래그 핸들
+ *  - 드래그 → 패널 너비 조절 (min 260px, max 600px)
+ *  - 내부 그리드 (점수·메타)도 너비에 따라 2~3열 자동 전환
+ */
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { useUIStore } from '@/store/useUIStore'
+import { useGalaxyStore } from '@/store/useGalaxyStore'
+import { useRepoDetail } from '@/hooks/queries/useRepoDetail'
+import { useScoreHistory } from '@/hooks/queries/useScoreHistory'
+import { formatCount, timeAgo } from '@/utils/format'
+import ScoreChart from './ScoreChart'
+import RAGAnalysis from './RAGAnalysis'
+import LoadingSpinner from '@/components/common/LoadingSpinner'
+
+// ── 언어 → 색상 ───────────────────────────────────────────────────
+const LANGUAGE_COLORS: Record<string, string> = {
+  TypeScript: '#4f8ef7', JavaScript: '#f7d44f', Python:    '#4da8e0',
+  Go:         '#00d4c8', Rust:       '#f07050', Java:      '#e8a24a',
+  'C++':      '#e05080', Ruby:       '#d94040', Swift:     '#f05c30',
+  Kotlin:     '#b06cff', PHP:        '#9090e0', 'C#':      '#68c060',
+}
+
+// ── 점수 → 레이블 ─────────────────────────────────────────────────
+function activityLabel(score: number) {
+  if (score >= 80) return { text: 'Hot',     cls: 'bg-orange-500/20 text-orange-300 border-orange-500/30' }
+  if (score >= 50) return { text: 'Active',  cls: 'bg-blue-500/20 text-blue-300 border-blue-500/30' }
+  if (score >= 25) return { text: 'Quiet',   cls: 'bg-gray-500/20 text-gray-300 border-gray-500/30' }
+  return               { text: 'Dormant',    cls: 'bg-gray-800/60 text-gray-500 border-gray-700/30' }
+}
+
+function healthLabel(score: number) {
+  if (score < 10)  return { text: '🕳️ Blackhole', cls: 'bg-red-900/40 text-red-300 border-red-800/40' }
+  if (score < 35)  return { text: '⚠ Critical',   cls: 'bg-red-500/20 text-red-400 border-red-500/30' }
+  if (score < 60)  return { text: 'Stable',        cls: 'bg-yellow-500/20 text-yellow-300 border-yellow-500/30' }
+  return               { text: 'Healthy',           cls: 'bg-green-500/20 text-green-300 border-green-500/30' }
+}
+
+// ── 리사이즈 상수 ────────────────────────────────────────────────
+const MIN_WIDTH     = 260
+const MAX_WIDTH     = 600
+const DEFAULT_WIDTH = 320
+
+// ─────────────────────────────────────────────────────────────────
+export default function SidePanel() {
+  const { selectedRepoId, isPanelOpen, closePanel, toggleFavorite, isFavorite } = useUIStore()
+  const repositories = useGalaxyStore((s) => s.repositories)
+  const scores       = useGalaxyStore((s) => s.scores)
+
+  const panelRef   = useRef<HTMLDivElement>(null)
+  const favorite   = selectedRepoId ? isFavorite(selectedRepoId) : false
+
+  // ── 리사이즈 상태 ────────────────────────────────────────────
+  const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH)
+  const isResizingRef  = useRef(false)
+  const startXRef      = useRef(0)
+  const startWidthRef  = useRef(DEFAULT_WIDTH)
+
+  const onResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    isResizingRef.current  = true
+    startXRef.current      = e.clientX
+    startWidthRef.current  = panelWidth
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+  }, [panelWidth])
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!isResizingRef.current) return
+      // 왼쪽으로 드래그 = 패널 넓어짐 (오른쪽에 붙어 있으므로 부호 반대)
+      const delta   = startXRef.current - e.clientX
+      const newW    = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, startWidthRef.current + delta))
+      setPanelWidth(newW)
+    }
+    const onUp = () => {
+      if (!isResizingRef.current) return
+      isResizingRef.current = false
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+  }, [])
+
+  // ── 기본 데이터 ──────────────────────────────────────────────
+  const repo  = selectedRepoId ? repositories.find((r) => r.id === selectedRepoId) : null
+  const score = selectedRepoId ? scores[selectedRepoId] : undefined
+
+  // ── API 데이터 ───────────────────────────────────────────────
+  const { data: detail,  isLoading: detailLoading  } = useRepoDetail(selectedRepoId)
+  const { data: history, isLoading: historyLoading } = useScoreHistory(selectedRepoId)
+
+  // ── ESC 키 닫기 ──────────────────────────────────────────────
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isPanelOpen) closePanel()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [isPanelOpen, closePanel])
+
+  // ── 패널 외부 클릭 닫기 ───────────────────────────────────────
+  useEffect(() => {
+    if (!isPanelOpen) return
+    const onOutside = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        closePanel()
+      }
+    }
+    const timer = setTimeout(() => document.addEventListener('mousedown', onOutside), 100)
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener('mousedown', onOutside)
+    }
+  }, [isPanelOpen, closePanel])
+
+  // ── 반응형 열 수 ─────────────────────────────────────────────
+  const scoreCols = panelWidth >= 360 ? 3 : 2
+  const metaCols  = panelWidth >= 360 ? 3 : 3  // meta는 항상 3열
+
+  // ── 시각 파생값 ──────────────────────────────────────────────
+  const langColor   = (repo?.language && LANGUAGE_COLORS[repo.language]) || '#aabbcc'
+  const actBadge    = score ? activityLabel(score.activityScore) : null
+  const healthBadge = score ? healthLabel(score.healthScore)     : null
+  const trendSign   = score && score.trendDelta >= 0 ? '+' : ''
+
+  return (
+    <aside
+      ref={panelRef}
+      style={{ width: panelWidth }}
+      className={`
+        fixed top-0 right-0 h-full z-30
+        max-w-[100vw]
+        bg-black/95 border-l border-white/8
+        backdrop-blur-xl shadow-2xl
+        flex flex-col
+        transform transition-transform duration-300 ease-out
+        ${isPanelOpen ? 'translate-x-0' : 'translate-x-full'}
+      `}
+      aria-label="저장소 상세 패널"
+    >
+      {/* ── 리사이즈 핸들 (왼쪽 가장자리) ─────────────────────── */}
+      <div
+        className="absolute left-0 top-0 h-full w-1.5 cursor-col-resize z-10 group"
+        onMouseDown={onResizeStart}
+      >
+        {/* 호버 시 시각적 피드백 */}
+        <div className="h-full w-full group-hover:bg-white/20 transition-colors duration-150" />
+        {/* 핸들 중앙 점 3개 */}
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col gap-1 opacity-0 group-hover:opacity-60 transition-opacity">
+          {[0,1,2].map(i => (
+            <div key={i} className="w-0.5 h-0.5 rounded-full bg-white/60" />
+          ))}
+        </div>
+      </div>
+
+      {/* ── 헤더 ────────────────────────────────────────────────── */}
+      <div className="flex items-start justify-between px-4 pt-5 pb-4 border-b border-white/5 flex-shrink-0 pl-5">
+        <div className="flex-1 min-w-0 pr-3">
+          <h2 className="text-white font-mono font-bold text-sm leading-tight truncate">
+            {repo?.name ?? '...'}
+          </h2>
+          <p className="text-white/40 font-mono text-[10px] truncate mt-0.5">
+            {repo?.fullName ?? ''}
+          </p>
+          {repo?.language && (
+            <div className="flex items-center gap-1.5 mt-2">
+              <span
+                className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: langColor, boxShadow: `0 0 5px ${langColor}60` }}
+              />
+              <span className="text-[11px] font-mono" style={{ color: langColor }}>
+                {repo.language}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {repo?.htmlUrl && (
+            <a
+              href={repo.htmlUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-white/30 hover:text-white/70 transition-colors text-lg leading-none"
+              title="GitHub에서 열기"
+            >↗</a>
+          )}
+          <button
+            onClick={closePanel}
+            className="text-white/30 hover:text-white/70 transition-colors text-xl leading-none px-1"
+            aria-label="패널 닫기"
+          >×</button>
+        </div>
+      </div>
+
+      {/* ── 스크롤 영역 ──────────────────────────────────────────── */}
+      <div className="flex-1 overflow-y-auto overflow-x-hidden px-4 py-4 space-y-4 pl-5">
+
+        {/* ── 점수 뱃지 ────────────────────────────────────────── */}
+        {score && (
+          <div
+            className="grid gap-2"
+            style={{ gridTemplateColumns: `repeat(${scoreCols}, 1fr)` }}
+          >
+            <div className="bg-white/4 rounded-lg px-2 py-2.5 text-center border border-white/5">
+              <p className="text-[9px] text-white/35 font-mono uppercase tracking-wider mb-1">활동</p>
+              <p className="text-xl font-mono font-bold text-blue-300">{score.activityScore}</p>
+              {actBadge && (
+                <span className={`text-[8px] font-mono px-1 py-0.5 rounded border ${actBadge.cls}`}>
+                  {actBadge.text}
+                </span>
+              )}
+            </div>
+            <div className="bg-white/4 rounded-lg px-2 py-2.5 text-center border border-white/5">
+              <p className="text-[9px] text-white/35 font-mono uppercase tracking-wider mb-1">건강</p>
+              <p className={`text-xl font-mono font-bold ${score.healthScore < 10 ? 'text-red-400' : score.healthScore < 40 ? 'text-orange-300' : 'text-emerald-300'}`}>
+                {score.healthScore}
+              </p>
+              {healthBadge && (
+                <span className={`text-[8px] font-mono px-1 py-0.5 rounded border ${healthBadge.cls}`}>
+                  {healthBadge.text}
+                </span>
+              )}
+            </div>
+            {(scoreCols === 3) && (
+              <div className="bg-white/4 rounded-lg px-2 py-2.5 text-center border border-white/5">
+                <p className="text-[9px] text-white/35 font-mono uppercase tracking-wider mb-1">트렌드</p>
+                <p className={`text-xl font-mono font-bold ${score.trendDelta > 0 ? 'text-green-400' : score.trendDelta < 0 ? 'text-red-400' : 'text-white/50'}`}>
+                  {trendSign}{score.trendDelta}
+                </p>
+                <span className="text-[8px] font-mono text-white/25">vs 이전</span>
+              </div>
+            )}
+            {/* 좁은 뷰에서 트렌드는 인라인으로 */}
+            {(scoreCols === 2) && score.trendDelta !== undefined && (
+              <div className="col-span-2 flex items-center justify-between bg-white/3 rounded-lg px-3 py-1.5 border border-white/5">
+                <span className="text-[9px] text-white/35 font-mono uppercase tracking-wider">트렌드</span>
+                <span className={`text-sm font-mono font-bold ${score.trendDelta > 0 ? 'text-green-400' : score.trendDelta < 0 ? 'text-red-400' : 'text-white/50'}`}>
+                  {trendSign}{score.trendDelta}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ── 메타 정보 ────────────────────────────────────────── */}
+        {repo && (
+          <div
+            className="grid gap-x-2 gap-y-1.5 text-center"
+            style={{ gridTemplateColumns: `repeat(${metaCols}, 1fr)` }}
+          >
+            {[
+              { label: '⭐ Stars',  value: formatCount(repo.starCount) },
+              { label: '🍴 Forks',  value: formatCount(repo.forkCount) },
+              { label: '🐛 Issues', value: formatCount(repo.openIssueCount) },
+            ].map(({ label, value }) => (
+              <div key={label} className="bg-white/3 rounded-md px-2 py-1.5">
+                <p className="text-[9px] text-white/30 font-mono">{label}</p>
+                <p className="text-xs text-white/70 font-mono font-semibold">{value}</p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {repo && (
+          <p className="text-[10px] text-white/25 font-mono">
+            마지막 푸시: {timeAgo(repo.pushedAt)}
+          </p>
+        )}
+
+        {/* ── Topics 태그 ─────────────────────────────────────── */}
+        {repo && repo.topics.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {repo.topics.slice(0, 10).map((topic) => (
+              <span
+                key={topic}
+                className="text-[9px] font-mono px-2 py-0.5 rounded-full bg-white/5 text-white/40 border border-white/8"
+              >
+                {topic}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* ── 설명 ─────────────────────────────────────────────── */}
+        {(detail ?? repo)?.description && (
+          <p className="text-[11px] text-white/40 font-mono leading-relaxed line-clamp-3">
+            {(detail ?? repo)?.description}
+          </p>
+        )}
+
+        {/* ── 점수 차트 ──────────────────────────────────────────── */}
+        <div>
+          <p className="text-[10px] text-white/40 uppercase tracking-widest font-mono mb-2">24시간 점수 추이</p>
+          {historyLoading ? (
+            <div className="flex justify-center py-4"><LoadingSpinner size="sm" /></div>
+          ) : history && history.length > 0 ? (
+            <ScoreChart data={history} height={80} />
+          ) : (
+            <p className="text-[11px] text-white/25 font-mono py-3 text-center">데이터 없음</p>
+          )}
+        </div>
+
+        {detailLoading && (
+          <div className="flex items-center gap-2">
+            <LoadingSpinner size="sm" />
+            <span className="text-[11px] text-white/25 font-mono">상세 정보 로딩 중...</span>
+          </div>
+        )}
+
+        {/* ── RAG 분석 ─────────────────────────────────────────── */}
+        {selectedRepoId && repo && (
+          <RAGAnalysis repoId={selectedRepoId} repoName={repo.fullName} />
+        )}
+      </div>
+
+      {/* ── 하단: My Galaxy 토글 ──────────────────────────────────── */}
+      {selectedRepoId && (
+        <div className="flex-shrink-0 px-4 py-3 border-t border-white/5 pl-5">
+          <button
+            onClick={() => toggleFavorite(selectedRepoId)}
+            className={`
+              w-full flex items-center justify-center gap-2
+              py-2 rounded-lg border text-xs font-mono
+              transition-all duration-150
+              ${favorite
+                ? 'bg-yellow-500/15 border-yellow-500/30 text-yellow-300 hover:bg-yellow-500/25'
+                : 'bg-white/4 border-white/10 text-white/50 hover:bg-white/8 hover:text-white/80'
+              }
+            `}
+          >
+            <span className="text-base">{favorite ? '⭐' : '☆'}</span>
+            {favorite ? 'My Galaxy에서 제거' : 'My Galaxy에 추가'}
+          </button>
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/src/hooks/3d/usePhysics.ts
+++ b/src/hooks/3d/usePhysics.ts
@@ -1,0 +1,107 @@
+/**
+ * usePhysics.ts — N-body 물리 시뮬레이션
+ *
+ * Scene.tsx 내부(Canvas 안)에서 단 한 번 호출한다.
+ * physicsStore의 모든 별에 대해 매 프레임(2프레임마다 1회) 힘을 계산,
+ * 속도/위치를 갱신하고 Three.js 메시에 직접 적용한다.
+ * React 리렌더 없음 → 프레임 드랍 없이 50개 별 실시간 이동.
+ *
+ * 힘 구성:
+ *  1. 홈 스프링  : 드리프팅 성단 중심을 향한 복원력
+ *  2. N-body   : 같은 언어 = 인력, 모든 별 = 가까우면 척력
+ *  3. 감쇠     : 속도 × DAMPING (에너지 손실)
+ */
+
+import { useFrame } from '@react-three/fiber'
+import { useRef } from 'react'
+import { physicsStore } from '@/store/physicsStore'
+import {
+  getDriftingCenter,
+  computePairForce,
+  HOME_SPRING,
+  DAMPING,
+  MAX_SPEED,
+} from '@/utils/physics'
+
+// 물리 업데이트 주기 (2프레임마다 1회 → 30fps 물리)
+const PHYSICS_STRIDE = 2
+
+export function usePhysics() {
+  const frameRef = useRef(0)
+
+  useFrame((state, delta) => {
+    frameRef.current++
+    if (frameRef.current % PHYSICS_STRIDE !== 0) return
+
+    // 누적 델타를 감안한 실질 dt (최대 0.05 cap → 탭 비활성 후 복귀 시 폭발 방지)
+    const dt = Math.min(delta * PHYSICS_STRIDE, 0.05)
+    const time = state.clock.elapsedTime
+
+    const entries = physicsStore.getAll()
+    const n = entries.length
+    if (n === 0) return
+
+    // ── 임시 힘 누적 배열 ──────────────────────────────────────────
+    // Float32Array로 GC 압박 최소화
+    const forces = new Float32Array(n * 3) // [fx0,fy0,fz0, fx1,...]
+
+    for (let i = 0; i < n; i++) {
+      const a = entries[i]
+      const i3 = i * 3
+
+      // 1. 홈 스프링 (드리프팅 성단 중심으로 복원)
+      const [hx, hy, hz] = getDriftingCenter(a.language, time)
+      forces[i3]     += (hx - a.position.x) * HOME_SPRING
+      forces[i3 + 1] += (hy - a.position.y) * HOME_SPRING
+      forces[i3 + 2] += (hz - a.position.z) * HOME_SPRING
+
+      // 2. N-body 쌍힘 (대칭 이용 → j>i 만 계산, 반작용 동시 적용)
+      for (let j = i + 1; j < n; j++) {
+        const b = entries[j]
+        const j3 = j * 3
+
+        const [fx, fy, fz] = computePairForce(
+          a.position.x, a.position.y, a.position.z, a.language,
+          b.position.x, b.position.y, b.position.z, b.language,
+        )
+
+        forces[i3]     += fx
+        forces[i3 + 1] += fy
+        forces[i3 + 2] += fz
+        // 뉴턴 3법칙: b에는 반대 방향
+        forces[j3]     -= fx
+        forces[j3 + 1] -= fy
+        forces[j3 + 2] -= fz
+      }
+    }
+
+    // ── 속도·위치 갱신 + 메시 적용 ─────────────────────────────────
+    for (let i = 0; i < n; i++) {
+      const e = entries[i]
+      const i3 = i * 3
+
+      // 속도 갱신 + 감쇠
+      e.velocity.x = (e.velocity.x + forces[i3]     * dt) * DAMPING
+      e.velocity.y = (e.velocity.y + forces[i3 + 1] * dt) * DAMPING
+      e.velocity.z = (e.velocity.z + forces[i3 + 2] * dt) * DAMPING
+
+      // 최대 속력 제한
+      const spd = e.velocity.length()
+      if (spd > MAX_SPEED) e.velocity.multiplyScalar(MAX_SPEED / spd)
+
+      // 위치 갱신
+      e.position.x += e.velocity.x * dt
+      e.position.y += e.velocity.y * dt
+      e.position.z += e.velocity.z * dt
+
+      // Three.js Object3D(Group)에 직접 적용 (React 리렌더 없음)
+      if (e.object) {
+        e.object.position.copy(e.position)
+      }
+    }
+  })
+}
+
+// ── Lerp 유틸 (Star.tsx에서도 사용) ─────────────────────────────
+export { lerp } from '@/utils/physics'
+export { lerpStep } from '@/hooks/3d/useLerp'

--- a/src/hooks/queries/useRagAnalysis.ts
+++ b/src/hooks/queries/useRagAnalysis.ts
@@ -1,0 +1,79 @@
+/**
+ * useRagAnalysis.ts
+ *
+ * RAG(Retrieval-Augmented Generation) 분석 요청 훅.
+ * 사이드 패널의 "왜?" 버튼을 누르면 호출된다.
+ *
+ * API: POST /api/rag/analyze
+ * Body: { repoId, question? }
+ *
+ * [DEV 동작]
+ *  - API 실패 시 2초 지연 후 mock 분석 텍스트 반환
+ *  - 실제 LLM 응답 형식을 미리 체험할 수 있도록 사실적인 내용으로 구성
+ */
+
+import { useMutation } from '@tanstack/react-query'
+import { apiClient } from '@/api/axios'
+import type { RagAnalysisRequest, RagAnalysisResponse } from '@/types/github'
+
+// ── API 호출 ────────────────────────────────────────────────────────
+async function postRagAnalysis(req: RagAnalysisRequest): Promise<RagAnalysisResponse> {
+  const { data } = await apiClient.post<RagAnalysisResponse>('/api/rag/analyze', req)
+  return data
+}
+
+// ── Mock 응답 (BE 미준비 시) ─────────────────────────────────────────
+const MOCK_TEMPLATES = [
+  (name: string) =>
+    `**${name}** 저장소는 최근 24시간 동안 커밋 활동이 급증하며 트렌딩 지수가 상승했습니다.\n\n` +
+    `주요 요인:\n` +
+    `• **v2.x 릴리즈 준비**: 메인 브랜치에 대규모 기능 추가 PR이 병합되었습니다.\n` +
+    `• **커뮤니티 반응**: GitHub Stars가 지난 1주 대비 +12% 증가, HackerNews Show HN 섹션에서 토론이 활발합니다.\n` +
+    `• **README 업데이트**: 문서 개선으로 신규 기여자 유입이 증가했습니다.\n\n` +
+    `*참고: 이 분석은 README, 릴리즈 노트, 최근 이슈/PR 데이터를 기반으로 생성되었습니다.*`,
+
+  (name: string) =>
+    `**${name}** 의 활동 지수가 높은 이유를 분석했습니다.\n\n` +
+    `**기술적 관점**: 최근 성능 최적화 관련 이슈가 다수 해결되었으며, ` +
+    `컨트리뷰터 수가 전월 대비 23% 증가했습니다.\n\n` +
+    `**생태계 영향**: 이 프로젝트에 의존하는 하위 패키지 업데이트가 ` +
+    `연쇄적으로 발생하며 GitHub의 Dependency Graph 내 노출이 증가했습니다.\n\n` +
+    `**소셜 신호**: Twitter/X 개발자 커뮤니티에서 벤치마크 결과가 공유되며 ` +
+    `자연 유입 트래픽이 늘었습니다.`,
+]
+
+async function mockRagAnalysis(req: RagAnalysisRequest, repoName: string): Promise<RagAnalysisResponse> {
+  await new Promise((r) => setTimeout(r, 2000)) // LLM 응답 지연 시뮬레이션
+  const template = MOCK_TEMPLATES[req.repoId % MOCK_TEMPLATES.length]
+  return {
+    repoId: req.repoId,
+    question: req.question ?? '이 저장소의 활동이 증가한 이유는 무엇인가요?',
+    analysis: template(repoName),
+    sources: [
+      `https://github.com/${repoName}`,
+      `https://github.com/${repoName}/releases`,
+      'https://news.ycombinator.com/item?id=example',
+    ],
+    confidence: 0.82 + Math.random() * 0.1,
+    generatedAt: new Date().toISOString(),
+  }
+}
+
+// ── Hook ────────────────────────────────────────────────────────────
+/**
+ * @param repoName - 화면에 표시용 이름 (mock에서만 사용)
+ */
+export function useRagAnalysis(repoName: string) {
+  return useMutation<RagAnalysisResponse, Error, RagAnalysisRequest>({
+    mutationFn: async (req) => {
+      try {
+        return await postRagAnalysis(req)
+      } catch {
+        if (import.meta.env.DEV) {
+          return mockRagAnalysis(req, repoName)
+        }
+        throw new Error('AI 분석을 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.')
+      }
+    },
+  })
+}

--- a/src/hooks/queries/useRepoDetail.ts
+++ b/src/hooks/queries/useRepoDetail.ts
@@ -1,0 +1,72 @@
+/**
+ * useRepoDetail.ts
+ *
+ * 저장소 상세 정보를 BE REST API에서 가져온다.
+ * (GET /api/repos/{repoId})
+ *
+ * [DEV 동작]
+ *  - 실제 API 호출 시도 → 실패하면 더미 데이터 반환 (1초 지연 시뮬레이션)
+ *  - BE가 준비되면 추가 설정 없이 자동으로 실제 API 사용
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { apiClient } from '@/api/axios'
+import type { RepoDetail } from '@/types/github'
+import { useGalaxyStore } from '@/store/useGalaxyStore'
+
+// ── API 호출 ────────────────────────────────────────────────────────
+async function fetchRepoDetail(repoId: number): Promise<RepoDetail> {
+  const { data } = await apiClient.get<RepoDetail>(`/api/repos/${repoId}`)
+  return data
+}
+
+// ── 더미 fallback (BE 미준비 시) ─────────────────────────────────────
+function makeMockDetail(repoId: number, repos: ReturnType<typeof useGalaxyStore.getState>['repositories']): RepoDetail {
+  const repo = repos.find((r) => r.id === repoId)
+  const now = new Date().toISOString()
+  return {
+    id: repo?.id ?? repoId,
+    name: repo?.name ?? `repo-${repoId}`,
+    fullName: repo?.fullName ?? `owner/repo-${repoId}`,
+    description: repo?.description ?? null,
+    language: repo?.language ?? null,
+    topics: repo?.topics ?? [],
+    starCount: repo?.starCount ?? 0,
+    forkCount: repo?.forkCount ?? 0,
+    openIssueCount: repo?.openIssueCount ?? 0,
+    pushedAt: repo?.pushedAt ?? now,
+    htmlUrl: repo?.htmlUrl ?? `https://github.com/owner/repo-${repoId}`,
+    trendStatus: repo?.trendStatus ?? 'Stable',
+    // RepoDetail 전용 필드
+    ownerName: repo?.fullName?.split('/')[0] ?? 'unknown',
+    repoName: repo?.name ?? `repo-${repoId}`,
+    repoUrl: repo?.htmlUrl ?? `https://github.com/owner/repo-${repoId}`,
+    firstSeenAt: now,
+    lastSeenAt: now,
+    isDeleted: false,
+  }
+}
+
+// ── Hook ────────────────────────────────────────────────────────────
+export function useRepoDetail(repoId: number | null) {
+  const repositories = useGalaxyStore((s) => s.repositories)
+
+  return useQuery<RepoDetail>({
+    queryKey: ['repoDetail', repoId],
+    queryFn: async () => {
+      if (!repoId) throw new Error('repoId is null')
+      try {
+        return await fetchRepoDetail(repoId)
+      } catch {
+        // DEV 모드: API 실패 시 로컬 더미 데이터로 fallback
+        if (import.meta.env.DEV) {
+          await new Promise((r) => setTimeout(r, 300)) // 짧은 지연으로 로딩 체험
+          return makeMockDetail(repoId, repositories)
+        }
+        throw new Error(`저장소 정보를 불러오지 못했습니다. (id=${repoId})`)
+      }
+    },
+    enabled: repoId !== null,
+    staleTime: 1000 * 60 * 10, // 10분 캐시
+  })
+}

--- a/src/hooks/queries/useScoreHistory.ts
+++ b/src/hooks/queries/useScoreHistory.ts
@@ -1,0 +1,84 @@
+/**
+ * useScoreHistory.ts
+ *
+ * 저장소의 시계열 점수 데이터를 가져온다.
+ * (GET /api/repos/{repoId}/scores?from=...&to=...)
+ *
+ * 반환된 ScoreHistoryEntry[] 배열은 ScoreChart 컴포넌트에서
+ * 24시간 스파크라인 차트로 렌더링된다.
+ *
+ * [DEV 동작]
+ *  - API 실패 시 현재 점수 기반으로 24개 모의 히스토리 생성
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { apiClient } from '@/api/axios'
+import type { ScoreHistoryEntry } from '@/types/github'
+import { useGalaxyStore } from '@/store/useGalaxyStore'
+
+// ── API 호출 ────────────────────────────────────────────────────────
+async function fetchScoreHistory(
+  repoId: number,
+  from: string,
+  to: string,
+): Promise<ScoreHistoryEntry[]> {
+  const { data } = await apiClient.get<ScoreHistoryEntry[]>(
+    `/api/repos/${repoId}/scores`,
+    { params: { from, to } },
+  )
+  return data
+}
+
+// ── 모의 데이터 생성 (BE 미준비 시) ──────────────────────────────────
+function generateMockHistory(
+  baseActivity: number,
+  baseHealth: number,
+  points = 24,
+): ScoreHistoryEntry[] {
+  const now = Date.now()
+  return Array.from({ length: points }, (_, i) => {
+    const bucket = new Date(now - (points - 1 - i) * 3600_000).toISOString()
+    // 랜덤 워크로 자연스러운 변화
+    const drift = (Math.random() - 0.5) * 14
+    const activity = Math.max(0, Math.min(100, baseActivity + drift + (Math.random() - 0.5) * 8))
+    const health   = Math.max(0, Math.min(100, baseHealth   + (Math.random() - 0.5) * 6))
+    return {
+      bucket,
+      commitCount:    Math.round(Math.random() * 15),
+      prCount:        Math.round(Math.random() * 5),
+      issueCount:     Math.round(Math.random() * 8),
+      releaseCount:   Math.random() < 0.05 ? 1 : 0,
+      activeScore:    Math.round(activity),
+      healthScore:    Math.round(health),
+      brightnessScore: Math.round(activity * 0.8 + Math.random() * 10),
+      sizeScore:      Math.round(activity * 0.6 + Math.random() * 15),
+    }
+  })
+}
+
+// ── Hook ────────────────────────────────────────────────────────────
+export function useScoreHistory(repoId: number | null) {
+  const score = useGalaxyStore((s) => (repoId ? s.scores[repoId] : undefined))
+  const baseActivity = score?.activityScore ?? 50
+  const baseHealth   = score?.healthScore   ?? 50
+
+  return useQuery<ScoreHistoryEntry[]>({
+    queryKey: ['scoreHistory', repoId],
+    queryFn: async () => {
+      if (!repoId) throw new Error('repoId is null')
+      const to   = new Date().toISOString()
+      const from = new Date(Date.now() - 24 * 3600_000).toISOString()
+      try {
+        return await fetchScoreHistory(repoId, from, to)
+      } catch {
+        if (import.meta.env.DEV) {
+          await new Promise((r) => setTimeout(r, 200))
+          return generateMockHistory(baseActivity, baseHealth)
+        }
+        throw new Error(`점수 히스토리를 불러오지 못했습니다. (id=${repoId})`)
+      }
+    },
+    enabled: repoId !== null,
+    staleTime: 1000 * 60 * 5, // 5분 캐시 (실시간성 고려)
+  })
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,5 +18,5 @@ createRoot(document.getElementById('root')!).render(
     <QueryClientProvider client={queryClient}>
       <App />
     </QueryClientProvider>
-  </StrictMode>,
+  </StrictMode>
 )

--- a/src/store/physicsStore.ts
+++ b/src/store/physicsStore.ts
@@ -1,0 +1,74 @@
+/**
+ * physicsStore.ts — 모듈 레벨 물리 싱글톤
+ *
+ * React 상태가 아니므로 업데이트 시 리렌더 없이
+ * Three.js Object3D position을 직접 변경한다. (최고 성능)
+ *
+ * 흐름:
+ *  Star.tsx  → mount 시 register() 호출
+ *  Star.tsx  → group ref 연결 후 setObject() 호출
+ *  usePhysics → useFrame에서 step()으로 위치/속도 갱신 후 object.position 직접 set
+ *
+ * v2 변경: mesh → object (THREE.Object3D) 로 타입 완화
+ *          → Star 컴포넌트가 <group>으로 바뀌면서 Group ref를 등록할 수 있게 됨
+ */
+
+import * as THREE from 'three'
+
+export interface PhysicsEntry {
+  repoId: number
+  language: string | null
+  /** 현재 위치 (Three.js Vector3 — 직접 변경됨) */
+  position: THREE.Vector3
+  /** 현재 속도 */
+  velocity: THREE.Vector3
+  /**
+   * 연결된 Three.js Object3D(Group 또는 Mesh) — 위치가 여기에 직접 적용됨.
+   * Star.tsx에서 <group> ref를 등록한다.
+   */
+  object: THREE.Object3D | null
+}
+
+class PhysicsStore {
+  entries = new Map<number, PhysicsEntry>()
+
+  /** Star 마운트 시 호출 — 초기 위치와 언어로 엔트리 생성 */
+  register(
+    repoId: number,
+    position: [number, number, number],
+    language: string | null,
+  ): void {
+    if (this.entries.has(repoId)) return // 중복 방지
+    this.entries.set(repoId, {
+      repoId,
+      language,
+      position: new THREE.Vector3(...position),
+      // 초기 속도: 더 큰 랜덤 값 → 별들이 처음부터 활발하게 움직임
+      velocity: new THREE.Vector3(
+        (Math.random() - 0.5) * 0.5,
+        (Math.random() - 0.5) * 0.5,
+        (Math.random() - 0.5) * 0.15,
+      ),
+      object: null,
+    })
+  }
+
+  /** group/mesh ref가 준비된 후 호출 */
+  setObject(repoId: number, object: THREE.Object3D): void {
+    const e = this.entries.get(repoId)
+    if (e) e.object = object
+  }
+
+  /** Star 언마운트 시 정리 */
+  unregister(repoId: number): void {
+    this.entries.delete(repoId)
+  }
+
+  /** 전체 엔트리 배열 (물리 루프용) */
+  getAll(): PhysicsEntry[] {
+    return Array.from(this.entries.values())
+  }
+}
+
+/** 앱 전체에서 공유하는 싱글톤 인스턴스 */
+export const physicsStore = new PhysicsStore()

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -1,17 +1,55 @@
 import { create } from 'zustand'
 import type { UIStore } from '@/types/store'
 
-export const useUIStore = create<UIStore>((set) => ({
-  // ── State ──
+export const useUIStore = create<UIStore>((set, get) => ({
+  // ── State ──────────────────────────────────────────────────────
   selectedRepoId: null,
   isPanelOpen: false,
   hoveredRepoId: null,
+  filterMode: 'all',
+  favorites: [],
+  user: null,
+  followedRepoId: null,
 
-  // ── Actions ──
+  // ── 기본 인터랙션 ───────────────────────────────────────────────
   selectRepo: (repoId) =>
-    set({ selectedRepoId: repoId, isPanelOpen: repoId !== null }),
+    set({
+      selectedRepoId: repoId,
+      isPanelOpen: repoId !== null,
+      // 별 클릭 시 카메라 추적도 같이 설정
+      followedRepoId: repoId,
+    }),
 
   setHovered: (repoId) => set({ hoveredRepoId: repoId }),
 
-  closePanel: () => set({ selectedRepoId: null, isPanelOpen: false }),
+  closePanel: () =>
+    set({
+      selectedRepoId: null,
+      isPanelOpen: false,
+      // 패널 닫으면 카메라 추적도 해제 → 자유 탐험 모드로
+      followedRepoId: null,
+    }),
+
+  // ── 필터 / My Galaxy ────────────────────────────────────────────
+  setFilterMode: (mode) => set({ filterMode: mode }),
+
+  toggleFavorite: (repoId) =>
+    set((state) => {
+      const already = state.favorites.includes(repoId)
+      return {
+        favorites: already
+          ? state.favorites.filter((id) => id !== repoId)
+          : [...state.favorites, repoId],
+      }
+    }),
+
+  /** 즐겨찾기 여부 확인 — get() 사용 (set 필요 없음) */
+  isFavorite: (repoId) => get().favorites.includes(repoId),
+
+  // ── 사용자 ──────────────────────────────────────────────────────
+  setUser: (user) => set({ user }),
+
+  // ── 카메라 추적 ─────────────────────────────────────────────────
+  /** 카메라 추적 대상 설정 (null = 자유 탐험) */
+  setCameraFollow: (repoId) => set({ followedRepoId: repoId }),
 }))

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -11,6 +11,7 @@ export interface Repository {
   openIssueCount: number
   pushedAt: string    // ISO 8601
   htmlUrl: string
+  trendStatus?: 'Rising' | 'Hot' | 'Stable' | 'Declining' | 'Unknown'
 }
 
 /** 저장소 활동 점수 (BE에서 산출) */
@@ -28,4 +29,58 @@ export interface RepoScoreEvent {
   repoId: number
   repoName: string
   score: RepoScore
+}
+
+// ──────────────────────────────────────────────────────────────────
+// 상세 조회 / 시계열 / RAG / 사용자 타입
+// ──────────────────────────────────────────────────────────────────
+
+/** 저장소 상세 정보 (GET /api/repos/{repoId}) */
+export interface RepoDetail extends Repository {
+  ownerName: string
+  repoName: string
+  repoUrl: string
+  firstSeenAt: string     // ISO 8601 — 우리 시스템 최초 발견일
+  lastSeenAt: string      // ISO 8601 — 마지막 업데이트
+  isDeleted: boolean
+}
+
+/**
+ * 시계열 점수 한 버킷 (GET /api/repos/{repoId}/scores)
+ * repo_time 테이블 row에 대응
+ */
+export interface ScoreHistoryEntry {
+  bucket: string         // ISO 8601 — 집계 시각 (예: "2026-04-27T14:00:00Z")
+  commitCount: number
+  prCount: number
+  issueCount: number
+  releaseCount: number
+  activeScore: number    // 별 밝기 기준 (0~100)
+  healthScore: number    // 블랙홀 판정 기준 (0~100)
+  brightnessScore: number
+  sizeScore: number
+}
+
+/** RAG 분석 요청 body (POST /api/rag/analyze) */
+export interface RagAnalysisRequest {
+  repoId: number
+  question?: string      // 없으면 BE 기본 질문 사용
+}
+
+/** RAG 분석 응답 */
+export interface RagAnalysisResponse {
+  repoId: number
+  question: string
+  analysis: string       // LLM이 생성한 분석 텍스트
+  sources: string[]      // 참조한 원본 URL 목록
+  confidence: number     // 0.0 ~ 1.0
+  generatedAt: string    // ISO 8601
+}
+
+/** GitHub OAuth 로그인 후 반환되는 사용자 정보 (GET /api/users/me) */
+export interface UserInfo {
+  userId: number
+  username: string         // GitHub 로그인 ID
+  profileImageUrl: string  // GitHub 아바타 URL
+  email: string | null
 }

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,4 +1,4 @@
-import type { Repository, RepoScore } from './github'
+import type { Repository, RepoScore, UserInfo } from './github'
 import type { StarProps } from './canvas'
 
 // ──────────────────────────────────────────────────────────────────
@@ -41,6 +41,9 @@ export type GalaxyStore = GalaxyState & GalaxyActions
 // UI Store — 인터랙션 상태
 // ──────────────────────────────────────────────────────────────────
 
+/** 3D 씬 필터 모드 (9~10주차 My Galaxy) */
+export type FilterMode = 'all' | 'my-galaxy'
+
 export interface UIState {
   /** 현재 선택된 별의 repoId (null = 선택 없음) */
   selectedRepoId: number | null
@@ -48,12 +51,42 @@ export interface UIState {
   isPanelOpen: boolean
   /** 툴팁 표시 대상 repoId (hover) */
   hoveredRepoId: number | null
+
+  /** 씬 필터 모드 (전체 / My Galaxy) */
+  filterMode: FilterMode
+  /**
+   * 즐겨찾기(My Galaxy) 저장소 ID 목록.
+   * 로컬에서 관리 → 9~10주차 BE /api/users/me/favorites 연동 예정
+   */
+  favorites: number[]
+
+  /** 로그인한 사용자 정보 (null = 비로그인) */
+  user: UserInfo | null
+
+  /**
+   * 카메라가 추적할 별의 repoId.
+   * null = 자유 탐험 모드, 숫자 = 해당 별로 카메라 이동 + 추적
+   */
+  followedRepoId: number | null
 }
 
 export interface UIActions {
   selectRepo: (repoId: number | null) => void
   setHovered: (repoId: number | null) => void
   closePanel: () => void
+
+  /** 씬 필터 전환 */
+  setFilterMode: (mode: FilterMode) => void
+  /** 즐겨찾기 토글 (추가/제거) */
+  toggleFavorite: (repoId: number) => void
+  /** 즐겨찾기 여부 확인 */
+  isFavorite: (repoId: number) => boolean
+
+  /** 로그인 사용자 정보 세팅 (OAuth 콜백 후 호출) */
+  setUser: (user: UserInfo | null) => void
+
+  /** 카메라 추적 대상 설정 (null = 추적 해제, 자유 탐험) */
+  setCameraFollow: (repoId: number | null) => void
 }
 
 export type UIStore = UIState & UIActions

--- a/src/utils/physics.ts
+++ b/src/utils/physics.ts
@@ -4,9 +4,17 @@
  * 포함:
  *  1. Lerp 함수 (스칼라 / Vector3)
  *  2. 점수 → 시각 속성 변환
- *  3. 언어별 성단 중심 좌표 + 드리프트 (느린 공전)
+ *  3. 언어별 성단 기준 좌표 & 드리프트(참고용, Cluster는 실제 centroid 사용)
  *  4. N-body 물리 상수 및 힘 계산 헬퍼
  *  5. 별 초기 위치 생성 (클러스터 기반)
+ *
+ * v2 물리 튜닝:
+ *  - HOME_SPRING 0.022 → 0.005 : 홈 복원력 대폭 약화 → 별이 자유롭게 유영
+ *  - DAMPING 0.94 → 0.91       : 감쇠 감소 → 더 생동감 있는 움직임
+ *  - MAX_SPEED 0.45 → 1.2      : 최대 속력 증가
+ *  - ATTRACTION_K 0.018 → 0.040: 동일 언어 인력 강화 → 또렷한 클러스터 형성
+ *  - REPULSION_K 2.8 → 3.8     : 겹침 방지 강화
+ *  - ATTRACTION_RANGE 55 → 75  : 인력 유효 범위 확장
  */
 
 import type { Vector3 } from 'three'
@@ -35,32 +43,29 @@ export function lerpVec3(
 // 2. 점수 → 시각 속성
 // ─────────────────────────────────────────────────────────────────
 
-/** activityScore(0~100) → 별 반지름(0.3~3.0) */
+/** activityScore(0~100) → 별 반지름(0.4~3.5) */
 export function scoreToRadius(score: number): number {
-  return 0.3 + (Math.max(0, Math.min(100, score)) / 100) * 2.7
+  return 0.4 + (Math.max(0, Math.min(100, score)) / 100) * 3.1
 }
 
-/** healthScore(0~100) → emissive 강도(0.1~2.5) */
+/** healthScore(0~100) → emissive 강도(0.1~2.8) */
 export function scoreToEmissiveIntensity(healthScore: number): number {
-  return 0.1 + (Math.max(0, Math.min(100, healthScore)) / 100) * 2.4
+  return 0.1 + (Math.max(0, Math.min(100, healthScore)) / 100) * 2.7
 }
 
 // ─────────────────────────────────────────────────────────────────
 // 3. 언어별 성단 기준 좌표 & 드리프트
 // ─────────────────────────────────────────────────────────────────
 //
-// 실제 성단 이미지에서 영감:
-//   TypeScript  → 플레이아데스(Pleiades)  : 파란 산개성단, 중밀도
-//   JavaScript  → 이중성단(Double)         : 두 무리, 따뜻한 노랑
-//   Python      → 오메가 센타우리(Omega Cen): 초고밀도 구상성단
-//   Go          → 나비 성단(Butterfly)     : 나비 모양 두 날개
-//   Rust        → 소원의 우물(Wishing Well) : 붉은·주황 색감
-//   Java        → 프레세페(Praesepe)       : 중밀도 노란 산개
-//   C++         → 머리털자리(Coma)         : 분산, 핑크
-//   Ruby        → 히아데스(Hyades)         : 가장 가까운 V자 배열
-//   Swift       → 페르세우스(Perseus Alpha) : 아름다운 파랑+주황
+// 주요 성단 배치:
+//   TypeScript  → 플레이아데스(Pleiades)      : 파란 산개성단, 중밀도
+//   JavaScript  → 이중성단(Double Cluster)    : 두 무리, 따뜻한 노랑
+//   Python      → 오메가 센타우리(Omega Cen)   : 초고밀도 구상성단
+//   Go          → 나비 성단(Butterfly)        : 나비 모양 두 날개
+//   Rust        → 소원의 우물(Wishing Well)   : 붉은·주황 색감
+//   Java        → 프레세페(Praesepe)          : 중밀도 노란 산개
 
-const CLUSTER_BASES: Record<string, [number, number, number]> = {
+export const CLUSTER_BASES: Record<string, [number, number, number]> = {
   TypeScript:  [ 85,  40,  8],
   JavaScript:  [ 55, -42,  0],
   Python:      [-90,  25,  5],
@@ -79,49 +84,49 @@ const CLUSTER_BASES: Record<string, [number, number, number]> = {
 
 /**
  * 시간에 따라 천천히 움직이는 성단 중심 좌표.
- * 각 언어마다 위상(phase)이 달라 서로 다른 리듬으로 움직인다.
+ * Cluster.tsx의 초기화/fallback에서만 사용.
+ * 실제 운용은 physicsStore centroid를 따름.
  */
 export function getDriftingCenter(
   language: string | null,
   time: number,
 ): [number, number, number] {
   const base = language ? (CLUSTER_BASES[language] ?? [0, 0, 0]) : [0, 0, 0]
-  // 언어 첫 글자 코드로 위상 결정 → 언어마다 다른 궤도
   const phase = language ? language.charCodeAt(0) * 1.618 : 0
-  const amp = 14  // 진폭 (단위 거리)
+  const amp = 6  // 진폭 축소 (실제 별 움직임과 혼동 방지)
 
   return [
-    base[0] + Math.sin(time * 0.11 + phase) * amp,
-    base[1] + Math.cos(time * 0.08 + phase * 1.3) * (amp * 0.8),
-    base[2] + Math.sin(time * 0.06 + phase * 0.7) * (amp * 0.4),
+    base[0] + Math.sin(time * 0.09 + phase) * amp,
+    base[1] + Math.cos(time * 0.07 + phase * 1.3) * (amp * 0.8),
+    base[2] + Math.sin(time * 0.05 + phase * 0.7) * (amp * 0.4),
   ]
 }
 
-/** 성단 중심 좌표 (드리프트 없는 고정값, Cluster 컴포넌트 초기화용) */
+/** 성단 기준 좌표 (드리프트 없는 고정값) */
 export function getBaseCenter(language: string | null): [number, number, number] {
   return language ? (CLUSTER_BASES[language] ?? [0, 0, 0]) : [0, 0, 0]
 }
 
 // ─────────────────────────────────────────────────────────────────
-// 4. N-body 물리 상수
+// 4. N-body 물리 상수 (v2 — 더 역동적인 움직임)
 // ─────────────────────────────────────────────────────────────────
 
 /** 같은 언어 별끼리 끌어당기는 강도 */
-export const ATTRACTION_K = 0.018
-/** 다른 언어 별에게 밀려나는 강도 */
-export const REPULSION_K = 2.8
-/** 성단 중심으로 끌리는 스프링 상수 */
-export const HOME_SPRING = 0.022
-/** 속도 감쇠 (1프레임당) */
-export const DAMPING = 0.94
-/** 최대 속력 (units/s) */
-export const MAX_SPEED = 0.45
+export const ATTRACTION_K = 0.040
+/** 모든 별 사이 척력 강도 (겹침 방지) */
+export const REPULSION_K = 3.8
+/** 성단 기준점으로 끌리는 스프링 상수 (약하게 → 별이 자유롭게 유영) */
+export const HOME_SPRING = 0.005
+/** 속도 감쇠 (값이 낮을수록 더 오래 움직임) */
+export const DAMPING = 0.91
+/** 최대 속력 (units/frame, 실제 units/s ÷ 60fps 내외) */
+export const MAX_SPEED = 1.2
 /** 최소 거리 (0 나누기 방지) */
-export const MIN_DIST = 5.0
+export const MIN_DIST = 4.5
 /** 동일 언어 인력 유효 범위 */
-export const ATTRACTION_RANGE = 55
-/** 타 언어 척력 유효 범위 */
-export const REPULSION_RANGE = 28
+export const ATTRACTION_RANGE = 75
+/** 척력 유효 범위 */
+export const REPULSION_RANGE = 30
 
 // ─────────────────────────────────────────────────────────────────
 // 5. 초기 클러스터 배치 위치 생성
@@ -129,17 +134,17 @@ export const REPULSION_RANGE = 28
 
 /**
  * 언어 기반 클러스터 중심 + 랜덤 오프셋으로 초기 위치 생성.
- * 물리 시뮬레이션 시작 전 초기값으로만 쓰인다.
+ * spread 확대(→38) → 초기 분산이 커서 물리가 더 역동적으로 시작됨.
  */
 export function generateClusteredPosition(
   language: string | null,
 ): [number, number, number] {
   const base = language ? (CLUSTER_BASES[language] ?? [0, 0, 0]) : [0, 0, 0]
-  const spread = 28
+  const spread = 38
   return [
     base[0] + (Math.random() - 0.5) * spread,
     base[1] + (Math.random() - 0.5) * spread,
-    base[2] + (Math.random() - 0.5) * spread * 0.5,
+    base[2] + (Math.random() - 0.5) * spread * 0.6,
   ]
 }
 
@@ -148,9 +153,8 @@ export function generateClusteredPosition(
 // ─────────────────────────────────────────────────────────────────
 
 /**
- * 두 별 사이의 힘을 계산하여 entryA의 가속도(fx, fy, fz)에 누적한다.
- *
- * @returns [fx, fy, fz] 증분값
+ * 두 별 사이의 힘을 계산. entryA에 적용할 [fx, fy, fz]를 반환.
+ * 뉴턴 3법칙으로 entryB에는 반대 방향 힘이 적용된다.
  */
 export function computePairForce(
   ax: number, ay: number, az: number, langA: string | null,
@@ -163,7 +167,7 @@ export function computePairForce(
   if (dist < 0.001) return [0, 0, 0]
 
   const clampedDist = Math.max(dist, MIN_DIST)
-  const nx = dx / dist  // 정규화 방향
+  const nx = dx / dist
   const ny = dy / dist
   const nz = dz / dist
 
@@ -171,7 +175,7 @@ export function computePairForce(
 
   let fx = 0, fy = 0, fz = 0
 
-  // 같은 언어: 인력 (서로 끌어당김)
+  // 같은 언어: 인력 (클러스터 형성)
   if (sameLang && dist < ATTRACTION_RANGE) {
     const f = ATTRACTION_K / (clampedDist * clampedDist)
     fx += nx * f
@@ -179,7 +183,7 @@ export function computePairForce(
     fz += nz * f
   }
 
-  // 가까울 때: 모든 별끼리 척력 (겹침 방지)
+  // 근접 시: 척력 (겹침/밀집 방지)
   if (dist < REPULSION_RANGE) {
     const f = REPULSION_K / (clampedDist * clampedDist)
     fx -= nx * f


### PR DESCRIPTION
## 개요
GitHub 오픈소스 저장소를 3D 은하로 시각화하는 프론트엔드 초기 구현입니다.

## 주요 변경사항

### ✨ 새 기능
- N-body 물리 시뮬레이션: 같은 언어 별끼리 인력, 전체 척력으로 자연스러운 성단 형성
- 5각별 3D 모양: 구체 → ExtrudeGeometry 별 모양으로 교체
- 360° 오비탈 카메라: 구면 좌표계 기반, 우주 어느 방향이든 자유 회전
- 별 클릭 추적: 클릭한 별로 카메라 줌인 + 이동하는 별 실시간 추적
- 사이드 패널: 저장소 상세 정보, 24시간 점수 차트, AI 분석, 리사이즈 가능
- 블랙홀 이펙트: healthScore < 10 시 강착원반 파티클 표시
- 밀도 반응 성단 glow: 별이 뭉칠수록 배경 성운 밝아짐

### 🐛 버그 수정
- R3F position prop 재적용 버그: 리렌더 시마다 물리 계산 위치가 초기값으로 리셋되던 문제 수정

## 스크린샷
(실행 화면 캡처 첨부)

## 테스트 방법
\`\`\`bash
cd frontend
npm install
npm run dev
\`\`\`

## 관련 이슈
Closes #12, #13, #14, #15, #16, #17, #18

## 체크리스트
- [ ] `npm run build` 빌드 통과
- [ ] TypeScript 에러 없음
- [ ] BE 연동 전 DEV 목 데이터로 정상 동작 확인